### PR TITLE
feat: adds support for preemptible node pools

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -170,6 +170,16 @@ spec:
           - name: STORAGE_CLASS
             value: "{{- . }}"
           {{- end }}
+          {{- with .Values.orchestrator.preemptible }}
+          {{- with .nodeSelector }}
+          - name: PREEMPTIBLE_NODE_SELECTOR
+            value: "{{- . }}"
+          {{- end }}
+          {{- with .taint }}
+          - name: PREEMPTIBLE_TAINT
+            value: "{{- . }}"
+          {{- end }}
+          {{- end }}
 ---
 # Deployment for the Planetary task monitor
 apiVersion: apps/v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -95,6 +95,18 @@ orchestrator:
     limits:
       memory: 4Gi
   log: info
+  # Configuration for scheduling preemptible tasks.
+  preemptible: null
+  #   # The node selector to apply to preemptible tasks.
+  #   #
+  #   # - For Azure Kubernetes Service (AKS), this should be
+  #   #   "kubernetes.azure.com/scalesetpriority=spot".
+  #   nodeSelector: "kubernetes.azure.com/scalesetpriority=spot"
+  #   # The taint to apply to preemptible tasks.
+  #   #
+  #   # - For Azure Kubernetes Service (AKS), this should be
+  #   #   "kubernetes.azure.com/scalesetpriority=spot:NoSchedule".
+  #   taint: "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"
 
 # Configuration relating to the monitor service that is responsible
 # for ensuring tasks do not become orphaned.

--- a/orchestrator/CHANGELOG.md
+++ b/orchestrator/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added support for preemptible node pools ([#22](https://github.com/stjude-rust-labs/planetary/pull/22)).
 * Added retry for Kubernetes API calls ([#21](https://github.com/stjude-rust-labs/planetary/pull/21)).
 * Log errors to the database ([#15](https://github.com/stjude-rust-labs/planetary/pull/15)).
 * Added endpoints for getting task I/O and updating a task's outputs, which is

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -92,6 +92,14 @@ pub struct Args {
     /// Defaults to `2.0` GiB.
     #[clap(long, env)]
     transporter_memory: Option<f64>,
+
+    /// The node selector to apply to preemptible tasks.
+    #[clap(long, env)]
+    preemptible_node_selector: Option<String>,
+
+    /// The taint to apply to preemptible tasks.
+    #[clap(long, env)]
+    preemptible_taint: Option<String>,
 }
 
 impl Args {
@@ -177,6 +185,8 @@ pub async fn main() -> anyhow::Result<()> {
         .maybe_tasks_namespace(args.tasks_namespace)
         .maybe_transporter_cpu(args.transporter_cpu)
         .maybe_transporter_memory(args.transporter_memory)
+        .maybe_preemptible_node_selector(args.preemptible_node_selector)
+        .maybe_preemptible_taint(args.preemptible_taint)
         .build()
         .run(terminate())
         .await


### PR DESCRIPTION
This PR adds generalized support for preemptible node pools.

It accomplishes this by setting two properties on any pod executing a `preemptible: true` task:

- It adds a node selector for nodes in the preemptible pool.
- It adds a taint toleration for the preemptible pool.

Right now, this assumes both are required to uniquely schedule tasks on _only_ the preemptible node pool, as that appears to be the way it works in Azure.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

Repository specific checklist:

- [x] If you update the supported TES version, you should change the version at
      `planetary::server::TES_VERSION`.
- [x] Make sure that (a) none of the changes conflict with information we lay 
      out in the "Security Notice" section of the `README.md` and (b) anything
      that needs to be added to that section is added.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
