### PR TITLE
feat: adds automated database setup and migrations

### DIFF
--- a/chart/CHANGELOG.md
+++ b/chart/CHANGELOG.md
@@ -9,4 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added automatic database migrations via a Kubernetes Job that runs on chart installation and upgrade ([#24](https://github.com/stjude-rust-labs/planetary/pull/24)).
 * Added optional pod-based PostgreSQL database to Helm chart ([#23](https://github.com/stjude-rust-labs/planetary/pull/23)).

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,4 +1,13 @@
-1. Get the API service URL by running these commands:
+1. Database migration job is running in the background. This job will:
+     - Wait for the database to be ready (up to 10 minutes)
+     - Create the database if it doesn't exist
+     - Run any pending migrations
+
+   You can check the migration status with:
+     kubectl get jobs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=migration
+     kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=migration --tail=-1
+
+2. Get the API service URL by running these commands:
 {{- if contains "NodePort" .Values.api.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" svc planetary-api)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/chart/templates/job.yaml
+++ b/chart/templates/job.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: planetary-db-migration-job-{{ randAlphaNum 10 | lower }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migration
+spec:
+  activeDeadlineSeconds: 600
+  template:
+    metadata:
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migration
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: wait-for-db
+          image: busybox:latest
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z ${DATABASE_HOST} ${DATABASE_PORT}; do
+                echo "Waiting for database at ${DATABASE_HOST}:${DATABASE_PORT}..."
+                sleep 10
+              done
+              echo "Database is ready!"
+          env:
+            - name: DATABASE_HOST
+              value: {{ .Values.database.host }}
+            - name: DATABASE_PORT
+              value: "{{ .Values.database.port }}"
+      containers:
+        - name: migration
+          image: "{{ .Values.migration.image.name }}:{{ .Values.migration.image.tag | default .Chart.AppVersion }}"
+          securityContext:
+            runAsUser: 1001
+            runAsNonRoot: true
+          env:
+            - name: DATABASE_USER
+              value: {{ .Values.database.user }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.passwordSecret }}
+                  key: {{ .Values.database.passwordSecretKey }}
+            - name: DATABASE_HOST
+              value: {{ .Values.database.host }}
+            - name: DATABASE_PORT
+              value: "{{ .Values.database.port }}"
+            - name: DATABASE_NAME
+              value: {{ .Values.database.name }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              export PGPASSWORD="${DATABASE_PASSWORD}"
+              export DATABASE_URL="postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}"
+
+              echo "Checking if database '${DATABASE_NAME}' exists..."
+              if [ "$(psql -h ${DATABASE_HOST} -p ${DATABASE_PORT} -U ${DATABASE_USER} -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='${DATABASE_NAME}'" 2>/dev/null)" != "1" ]; then
+                echo "Database does not exist, running setup and migrations..."
+                diesel setup --database-url="${DATABASE_URL}"
+                echo "Database setup and migrations completed successfully"
+              else
+                echo "Database already exists, running database migrations..."
+                diesel migration run --database-url="${DATABASE_URL}"
+                echo "Database migrations completed successfully"
+              fi
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+  backoffLimit: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -140,3 +140,9 @@ transporter:
     #   # The Google Cloud Storage HMAC secret to use for authentication.
     #   # Required if `hmacAccessKey` is set.
     #   hmacSecret: "<secret>"
+
+# Configuration relating to database migrations.
+migration:
+  image:
+    name: stjude-rust-labs/planetary-migration
+    tag: null


### PR DESCRIPTION
This PR automates the process of setting up the database and running migrations as part of the chart. It does this through a Kubernetes job that does the following:

1. Waits for the database connection to become available.
2. Checks if the database already exists: if it doesn't, it runs the setup command.
3. Last, it always runs the migrations.

This should make it far more streamlined to do the right thing without users needing to install the `diesel_cli` tool (somewhat of a pain).

I should not that I did try to get the `planetary-migrations` Docker image running on Alpine, but I failed to quickly getting it running, so I pivoted to Ubuntu for just this image.

Before submitting this PR, please make sure:

- [ ] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.

Repository specific checklist:

- [ ] If you update the supported TES version, you should change the version at
      `planetary::server::TES_VERSION`.
- [ ] Make sure that (a) none of the changes conflict with information we lay 
      out in the "Security Notice" section of the `README.md` and (b) anything
      that needs to be added to that section is added.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
