### PR TITLE
fix: ensure monitor finds missing Kubernetes resources.

### DIFF
--- a/monitor/CHANGELOG.md
+++ b/monitor/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Corrected several bugs in the monitor that prevented it from aborting tasks
+  that no longer have running pods ([#29](https://github.com/stjude-rust-labs/planetary/pull/29)).
+
 ## v0.1.0 (2025-10-13)
 
 #### Added


### PR DESCRIPTION
The monitor was filtering the pod map using a defunct label that was removed during a previous refactoring to the orchestrator. As a result, the pod map was always empty.

Additionally, there were two bugs in the check for missing Kubernetes resources:

* If the task had a pod, it would get aborted (luckily the pod map was always empty).
* The attempt to mark any associated PVC for garbage collection would have resulted in a failure due to the wrong object type being used in the `patch` call.

The fix is to build the pod map using the pod name, which is now always the TES id of the task, instead of the defunct label and to properly abort a task only if it doesn't have a pod.

<!--
When creating a pull request, you should uncomment the section below that
describes the type of pull request you are submitting.
-->

<!-- START SECTION: all pull requests

_Describe the problem or feature in addition to a link to the issues._

Before submitting this PR, please make sure:

- [ ] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.

Repository specific checklist:

- [ ] If you update the supported TES version, you should change the version at
      `planetary::server::TES_VERSION`.
- [ ] Make sure that (a) none of the changes conflict with information we lay 
      out in the "Security Notice" section of the `README.md` and (b) anything
      that needs to be added to that section is added.

END SECTION -->

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
