### PR TITLE
feat(chart): enables custom egress rules in dynamic network policies for tasks namespace

### DIFF
--- a/chart/CHANGELOG.md
+++ b/chart/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `transporter.storage.azure` values for Azure Storage authentication ([#27](https://github.com/stjude-rust-labs/planetary/pull/27)).
 * Added a 15 minute TTL on the migration job ([#25](https://github.com/stjude-rust-labs/planetary/pull/25)).
+* Addes dynamic egress network policy additions for cloud and user exceptions ([#34](https://github.com/stjude-rust-labs/planetary/pull/34)).
 
 ## v0.1.0 (2025-10-13)
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,33 @@
+# planetary
+
+`planetary` is a Kubernetes-based task executor for the Task Execution Service (TES) specification.
+
+## Configuration
+
+### Network Policies
+
+Network policies are disabled for task pods by default.
+In production deployments, it is recommeded you enable network policies for the task pods.
+
+The default network policy allows communication to `kube-dns` on port 53 - both UDP and TCP, HTTP communication back to the orchestrator, and all other IPv4 traffic on port 443.
+It is suggested that you review this network policy for your use case and determine if there are requirements where this policy is not strict enough.
+To fully lock down the task pods, we suggest a custom egress rule that allows internet connectivity on port 443 for all IPv4 ranges except the private CIDR ranges of your pods and services.
+An example looks like:
+
+```yaml
+networkPolicies:
+  enabled: true
+  egressRules:
+    - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          except:
+            - 10.244.0.0/16
+            - 10.0.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP
+```
+
+This allows communication to cloud specific services such as IDMS on Azure and any other private networks.
+Restrict further as needed if other network calls should not be allowed.

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.networkPolicies.enabled }}
 # Default deny ingress and egress for task pods
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -9,45 +10,44 @@ spec:
     - Ingress
     - Egress
 ---
-# Allow egress traffic to the public Internet from task pods
+# Allow accepted egress traffic from task pods
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: allow-internet-only
+  name: allow-exceptions
   namespace: {{ .Values.tasks.namespace }}
 spec:
   policyTypes:
-  - Egress
+    - Egress
   egress:
-  # Allow DNS to kube-dns
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: kube-dns
-    ports:
-      - port: 53
-        protocol: UDP
-      - port: 53
-        protocol: TCP
-  # Allow TCP to the orchestrator
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: {{ .Release.Namespace }}
-      podSelector:
-        matchLabels:
-          app.kubernetes.io/component: orchestrator
-    ports:
-      - port: {{ .Values.orchestrator.service.port }}
-        protocol: TCP
-  # Allow public Internet traffic
-  - to:
-    - ipBlock:
-        cidr: 0.0.0.0/0
-        except:
-          - 10.0.0.0/8
-          - 192.168.0.0/16
-          - 172.16.0.0/12
+    # Allow DNS to kube-dns
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+
+    # Allow TCP to the orchestrator
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/component: orchestrator
+      ports:
+        - port: {{ .Values.orchestrator.service.port }}
+          protocol: TCP
+
+    # Custom egress rules
+    {{- with .Values.networkPolicies.egressRules }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -166,3 +166,30 @@ migration:
   image:
     name: ghcr.io/stjude-rust-labs/planetary-migration
     tag: null
+
+# The Network Policies are disabled by default. If enabled, the defaults lock
+# down all communication except to `kube-dns`, the orchestrator, and the
+# public internet as seen below with the `egressRules` default.
+#
+# If you need other access, add egress rules below.
+networkPolicies:
+  enabled: false
+  egressRules:
+  # Allows for custom egress rules from the tasks namespace.
+  # Below is an example that allows public internet access but blocks a
+  # common pod and service CIDR range.
+  #
+  # - to:
+  #   - ipBlock:
+  #       cidr: 0.0.0.0/0
+  #       except:
+  #         - 10.244.0.0/16
+  #         - 10.0.0.0/16
+  #
+  # The default when enabled is allow all HTTPS traffic.
+    - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+      ports:
+        - port: 443
+          protocol: TCP


### PR DESCRIPTION
Network policies for the tasks namespace were blocking IDMS in Azure and a private endpoint subnet that blocked writing outputs to blob storage. This PR updates the network policies and breaks them into smaller policies for easier debugging along with a new dynamic section for adding cloud or user specific egress exceptions.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

Repository specific checklist:

- [x] If you update the supported TES version, you should change the version at
      `planetary::server::TES_VERSION`.
- [x] Make sure that (a) none of the changes conflict with information we lay 
      out in the "Security Notice" section of the `README.md` and (b) anything
      that needs to be added to that section is added.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
