### PR TITLE
feat: associate tasks with usernames.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,29 @@ There are currently four images created for use with Planetary:
 * `stjude-rust-labs/planetary-transporter` - implements the _Transporter_ used
   for downloading task inputs and uploading task outputs.
 
+### API Server Request Authentication
+
+The Planetary API server ***performs no authentication of requests***.
+
+However, requests must be associated with a username in one of two ways (in
+order of precedence):
+
+* The request includes a `X-Forwarded-User` header. This is typically set by
+  upstream authentication proxies that sit between the TES client and Planetary.
+
+* The request includes a basic `Authorization` header with a non-empty
+  username (***the password is ignored***). This can be used for testing
+  purposes with TES clients that support basic authentication.
+
+If a TES API request has neither header present, a 403 is returned from the
+Planetary API Server.
+
+Planetary uses the username specified in the header to associate tasks with
+that user.
+
+The user may only retrieve, list, and cancel tasks that with the _same_
+username.
+
 ### Supported Cloud Storage
 
 Planetary supports the following cloud storage services:

--- a/README.md
+++ b/README.md
@@ -380,35 +380,35 @@ To build the `stjude-rust-labs/planetary-api` container image, run the
 following command:
 
 ```bash
-docker build . --target planetary-api --tag stjude-rust-labs/planetary-api:staging
+docker build . --target planetary-api --tag stjude-rust-labs/planetary-api:dev
 ```
 
 To build the `stjude-rust-labs/planetary-orchestrator` container image, run the
 following command:
 
 ```bash
-docker build . --target planetary-orchestrator --tag stjude-rust-labs/planetary-orchestrator:staging
+docker build . --target planetary-orchestrator --tag stjude-rust-labs/planetary-orchestrator:dev
 ```
 
 To build the `stjude-rust-labs/planetary-orchestrator` container image, run the
 following command:
 
 ```bash
-docker build . --target planetary-monitor --tag stjude-rust-labs/planetary-monitor:staging
+docker build . --target planetary-monitor --tag stjude-rust-labs/planetary-monitor:dev
 ```
 
 To build the `stjude-rust-labs/planetary-transporter` container image,
 run the following command:
 
 ```bash
-docker build . --target planetary-transporter --tag stjude-rust-labs/planetary-transporter:staging
+docker build . --target planetary-transporter --tag stjude-rust-labs/planetary-transporter:dev
 ```
 
 To build the `stjude-rust-labs/planetary-migration` container image (for database migrations),
 run the following command:
 
 ```bash
-docker build . --target planetary-migration --tag stjude-rust-labs/planetary-migration:staging
+docker build . --target planetary-migration --tag stjude-rust-labs/planetary-migration:dev
 ```
 
 ### Loading the Container Images
@@ -419,11 +419,11 @@ following command:
 
 ```bash
 kind load docker-image -n planetary \
-  stjude-rust-labs/planetary-api:staging \
-  stjude-rust-labs/planetary-orchestrator:staging \
-  stjude-rust-labs/planetary-monitor:staging \
-  stjude-rust-labs/planetary-transporter:staging \
-  stjude-rust-labs/planetary-migration:staging
+  stjude-rust-labs/planetary-api:dev \
+  stjude-rust-labs/planetary-orchestrator:dev \
+  stjude-rust-labs/planetary-monitor:dev \
+  stjude-rust-labs/planetary-transporter:dev \
+  stjude-rust-labs/planetary-migration:dev
 ```
 
 ## ✨ Deploying Planetary
@@ -431,7 +431,7 @@ kind load docker-image -n planetary \
 > [!NOTE]
 > The Planetary Helm chart includes an optional pod-based PostgreSQL database
 > for local development and testing (enabled with `postgresql.enabled=true` in
-> `./chart/examples/staging.yaml`).
+> `./chart/examples/development.yaml`).
 >
 > In this guide, we'll deploy Planetary using this
 > ephemeral database. **This is for demonstration purposes only—for anything
@@ -463,12 +463,12 @@ managing [nfs-ganesha](https://github.com/nfs-ganesha/nfs-ganesha) services.
 ### Installing Planetary
 
 To deploy Planetary with the included PostgreSQL database into a local
-Kubernetes cluster, run the following command:
+development Kubernetes cluster, run the following command:
 
 ```bash
 helm upgrade --install --create-namespace -n planetary planetary chart \
   --set postgresql.password='<mypassword>' \
-  -f chart/examples/staging.yaml
+  -f chart/examples/development.yaml
 ```
 
 **Note:** Replace `<mypassword>` with a secure password of your choice.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Planetary API Server.
 Planetary uses the username specified in the header to associate tasks with
 that user.
 
-The user may only retrieve, list, and cancel tasks that with the _same_
+The user may only retrieve, list, and cancel tasks with the _same_
 username.
 
 ### Supported Cloud Storage

--- a/README.md
+++ b/README.md
@@ -55,62 +55,124 @@ aspects of security to ensure they meet your standards and adequately protect
 your environment.
 
 As a starting point, we recommend you review the following aspects of your
-deployment and the Helm chart. Keep in mind that this list is non-exhaustive, so
-you should do your own research to create a complete list of concerns to
-consider in your situation.
+deployment and the Helm chart.
 
-- **Ingress and external exposure.** The services provided by Planetary
-  include **no authentication or authorization at all and will accept and
-  execute unauthenticated requests if you do not take action to secure them
-  further**. It is imperative that you restrict these services using external
-  authentication and authorization mechanisms. Further, we encourage you to
-  review any Services or Ingress resources included in the chart to confirm they
-  are exposed only as needed. Ensure TLS termination, authentication,
-  authorization, and rate-limiting are configured according to your policies,
-  and integrate the service with a web application firewall.
-- **RBAC permissions.** We've scoped roles and bindings according to what we
-  believe to be least-privilege access. Review these to ensure they align with
-  your internal access control policies and compliance standards.
-- **Pod security contexts.** We’ve configured workloads to run as non-root
-  and use read-only file systems where possible. These measures help limit
-  container privileges and reduce the attack surface. Confirm these settings
-  meet your container hardening requirements for all deployments and containers.
-- **Network policies.** We include policies to restrict pod-to-pod ingress
-  and egress traffic, balancing security with ease of configuration. Validate
-  that these meet your segmentation, isolation, and ingress/egress control
-  goals.
-- **Secrets management.** We've defined Kubernetes Secrets where needed and
-  structured their use for secure injection. Verify these secrets meet your
-  standards for confidentiality, access control, and rotation.
-- **Credentials.** This chart does not provide default passwords or API
-  keys. You must set secure, unique credentials for all components before
-  deployment.
-- **Resource limits and requests.** We've set default CPU and memory
-  constraints to encourage efficient scheduling and prevent resource exhaustion.
+Keep in mind that this list is non-exhaustive, so you should do your own
+research to create a complete list of concerns to consider in your situation:
+
+- **Ingress and external exposure.**
+
+  The services provided by Planetary include ***no authentication at all and
+  will accept and execute unauthenticated requests if you do not take action to
+  secure them further***.
+
+  It is ***imperative*** that you restrict access to these services using
+  external authentication mechanisms.
+
+  The Planetary API server expects the authentication process to send the
+  request with the `X-Forwarded-User` header set to the username resulting from
+  authentication.
+
+  The header's value is ***implicitly trusted*** by the API server and is
+  unverified by Planetary. Allowing external clients direct access to the
+  Planetary API server would result in trivial authorization bypass.
+
+  Further, we encourage you to review any Services or Ingress resources
+  included in the chart to confirm they are exposed only as needed.
+
+  Ensure TLS termination, authentication, authorization, and rate-limiting are
+  configured according to your policies, and integrate the service with a web
+  application firewall.
+
+- **RBAC permissions.**
+
+  We've scoped roles and bindings according to what we believe to be
+  least-privilege access.
+
+  Review these to ensure they align with your internal access control policies
+  and compliance standards.
+
+- **Pod security contexts.**
+
+  We’ve configured workloads to run as non-root and use read-only file systems
+  where possible. These measures help limit container privileges and reduce the
+  attack surface.
+
+  Confirm these settings meet your container hardening requirements for all
+  deployments and containers.
+
+- **Network policies.**
+
+  We include policies to restrict pod-to-pod ingress and egress traffic,
+  balancing security with ease of configuration.
+
+  Validate that these meet your segmentation, isolation, and ingress/egress
+  control goals.
+
+- **Secrets management.**
+
+  We've defined Kubernetes Secrets where needed and structured their use for
+  secure injection.
+
+  Verify these secrets meet your standards for confidentiality, access control,
+  and rotation.
+
+- **Credentials.**
+
+  This chart does not provide default passwords or API keys.
+
+  You must set secure, unique credentials for all components before deployment.
+
+- **Resource limits and requests.**
+
+  We've set default CPU and memory constraints to encourage efficient
+  scheduling and prevent resource exhaustion.
+
   Adjust these for your expected workloads.
-- **Container images and supply chain security.** We use version-pinned
-  images from known registries. Review these to ensure they come from sources
-  you trust, are vulnerability-scanned, and, where appropriate, have verified
-  signatures.
-- **Monitoring, logging, and alerting.** Implement robust observability for
-  timely incident detection and response. Configure logging to avoid exposing
-  sensitive information, and ensure log retention complies with your policies.
-- **Automated compliance scanning.** Use automated Kubernetes security
-  scanners to verify compliance with your organizational policies.
-- **Upgrades and patch management.** Keep Planetary and its dependencies
-  up-to-date. We may publish chart updates in response to vulnerabilities, but
-  you are responsible for monitoring for published updates and applying them
-  promptly.
-- **Cluster environment assumptions.** This chart assumes it is deployed
-  into a hardened Kubernetes cluster (e.g., restricted API server access,
-  encrypted etcd, secure CSI drivers). Ensure your cluster meets these
-  prerequisites.
-- **Backups and disaster recovery.** If Planetary stores persistent state in
-  your environment, implement a tested backup and restore process.
+
+- **Container images and supply chain security.**
+
+  We use version-pinned images from known registries.
+
+  Review these to ensure they come from sources you trust, are
+  vulnerability-scanned, and, where appropriate, have verified signatures.
+
+- **Monitoring, logging, and alerting.**
+
+  Implement robust observability for timely incident detection and response.
+
+  Configure logging to avoid exposing sensitive information, and ensure log
+  retention complies with your policies.
+
+- **Automated compliance scanning.**
+
+  Use automated Kubernetes security scanners to verify compliance with your
+  organizational policies.
+
+- **Upgrades and patch management.**
+
+  Keep Planetary and its dependencies up-to-date.
+
+  We may publish chart updates in response to vulnerabilities, but you are
+  responsible for monitoring for published updates and applying them promptly.
+
+- **Cluster environment assumptions.**
+
+  This chart assumes it is deployed into a hardened Kubernetes cluster (e.g.,
+  restricted API server access, encrypted etcd, secure CSI drivers).
+
+  Ensure your cluster meets these prerequisites.
+
+- **Backups and disaster recovery.**
+
+  If Planetary stores persistent state in your environment, implement a tested
+  backup and restore process.
 
 We recommend regularly auditing your deployment to ensure continued security and
-operational integrity. Default settings may not be sufficient for all use
-cases—review and customize configurations as appropriate for your environment.
+operational integrity.
+
+Default settings may not be sufficient for all use cases; please review and
+customize configurations as appropriate for your environment.
 
 ### Architecture
 
@@ -160,8 +222,10 @@ order of precedence):
   upstream authentication proxies that sit between the TES client and Planetary.
 
 * The request includes a basic `Authorization` header with a non-empty
-  username (***the password is ignored***). This can be used for testing
-  purposes with TES clients that support basic authentication.
+  username (***the password is ignored***). The check for this header is
+  disabled by default and is only enabled if the `api.allowAuthorizationFallback`
+  value in the chart is set to `true`. This can be used for testing purposes
+  with TES clients that support basic authentication.
 
 If a TES API request has neither header present, a 403 is returned from the
 Planetary API Server.

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Added support for the `X-Forwarded-User` header for respecting the user
+  associated with TES API requests ([#40](https://github.com/stjude-rust-labs/planetary/pull/40)).
+
 #### Dependencies
 
 * Updated dependencies to latest ([#37](https://github.com/stjude-rust-labs/planetary/pull/37)).

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -4,10 +4,18 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use axum::response::Response;
+use axum_extra::TypedHeader;
+use axum_extra::headers::Authorization;
+use axum_extra::headers::authorization::Basic;
 use bon::Builder;
 use planetary_db::Database;
 use planetary_server::DEFAULT_ADDRESS;
 use planetary_server::DEFAULT_PORT;
+use planetary_server::Error;
 use reqwest::Client;
 use secrecy::SecretString;
 use tes::v1::types::responses::ServiceInfo;
@@ -40,6 +48,43 @@ fn notify_retry(e: &reqwest::Error, duration: Duration) {
         "network operation failed: {e} (retrying after {duration} seconds)",
         duration = duration.as_secs()
     );
+}
+
+/// An extension for passing the request username through from the
+/// authentication middleware.
+#[derive(Clone)]
+struct Username(String);
+
+/// Middleware function to perform auth lookup against the request.
+///
+/// This middleware does not actually perform any authentication of the user.
+///
+/// If the `X-Forwarded-User` header is present, it is respected over the
+/// `Authorization` header.
+///
+/// The intention of this middleware is to simply to enforce that a username was
+/// sent with the request.
+async fn auth(
+    authorization: Option<TypedHeader<Authorization<Basic>>>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    // First respect the `X-Forwarded-User` header, then the `Authorization` header
+    let username = match (
+        request
+            .headers()
+            .get("X-Forwarded-User")
+            .map(|v| v.to_str()),
+        &authorization,
+    ) {
+        (Some(Ok(username)), _) if !username.is_empty() => username,
+        (None, Some(auth)) if !auth.username().is_empty() => auth.username(),
+        _ => return Error::forbidden().into_response(),
+    }
+    .to_string();
+
+    request.extensions_mut().insert(Username(username));
+    next.run(request).await
 }
 
 /// Represents information about the orchestrator service.

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -65,6 +65,7 @@ struct Username(String);
 /// The intention of this middleware is to simply to enforce that a username was
 /// sent with the request.
 async fn auth(
+    allow_authorization_fallback: bool,
     authorization: Option<TypedHeader<Authorization<Basic>>>,
     mut request: Request,
     next: Next,
@@ -77,8 +78,12 @@ async fn auth(
             .map(|v| v.to_str()),
         &authorization,
     ) {
+        // Note: if the `X-Forwarded-User` is present but malformed (i.e. `Some(Err(_))`), then we
+        // intentionally return forbidden rather than look at the `Authorization` header
         (Some(Ok(username)), _) if !username.is_empty() => username,
-        (None, Some(auth)) if !auth.username().is_empty() => auth.username(),
+        (None, Some(auth)) if allow_authorization_fallback && !auth.username().is_empty() => {
+            auth.username()
+        }
         _ => return Error::forbidden().into_response(),
     }
     .to_string();
@@ -100,13 +105,10 @@ struct OrchestratorServiceInfo {
 struct State {
     /// The HTTP client for communicating with the orchestration service.
     client: Arc<Client>,
-
     /// The service information.
     info: Arc<ServiceInfo>,
-
     /// The TES database.
     database: Arc<dyn Database>,
-
     /// The orchestrator service information.
     orchestrator: Arc<OrchestratorServiceInfo>,
 }
@@ -158,6 +160,9 @@ pub struct Server {
     /// The Planetary orchestrator service API key.
     #[builder(into)]
     orchestrator_api_key: SecretString,
+
+    /// Whether or not to allow fallback to the `Authorization` header.
+    allow_authorization_fallback: bool,
 }
 
 impl<S: server_builder::State> ServerBuilder<S> {
@@ -185,7 +190,10 @@ impl Server {
         let server = planetary_server::Server::builder()
             .address(self.address)
             .port(self.port)
-            .routers(bon::vec![info::router(), tasks::router()])
+            .routers(bon::vec![
+                info::router(),
+                tasks::router(self.allow_authorization_fallback)
+            ])
             .build();
 
         let state = State::new(
@@ -194,6 +202,7 @@ impl Server {
             self.orchestrator_url,
             self.orchestrator_api_key,
         );
+
         server.run(state, shutdown).await?;
         Ok(())
     }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -155,6 +155,12 @@ pub struct Args {
     /// The Planetary orchestrator service API key.
     #[clap(long, env, hide_env_values(true))]
     orchestrator_api_key: SecretString,
+
+    /// Whether or not to allow fallback to the `Authorization` header.
+    ///
+    /// By default, only the `X-Forwarded-User` header is checked.
+    #[clap(long, env)]
+    allow_authorization_fallback: bool,
 }
 
 impl Args {
@@ -234,6 +240,7 @@ pub async fn main() -> anyhow::Result<()> {
         .shared_database(database)
         .orchestrator_url(args.orchestrator_url)
         .orchestrator_api_key(args.orchestrator_api_key)
+        .allow_authorization_fallback(args.allow_authorization_fallback)
         .info(ServiceInfo::try_from(args.service_info)?)
         .build()
         .run(terminate())

--- a/api/src/tasks.rs
+++ b/api/src/tasks.rs
@@ -10,7 +10,7 @@ use crate::State;
 mod v1;
 
 /// Gets the router for the service information.
-pub fn router() -> Router<State> {
+pub fn router(allow_authorization_fallback: bool) -> Router<State> {
     Router::new()
         .without_v07_checks()
         .route("/v1/tasks", get(v1::list_tasks))
@@ -19,5 +19,7 @@ pub fn router() -> Router<State> {
         // TODO: the path should be `/v1/tasks/{id}:cancel`, but that's not supported until
         // `matchit`` 0.8.6; we're currently on 0.8.4 via `axum`
         .route("/v1/tasks/{id}", post(v1::cancel_task))
-        .layer(middleware::from_fn(crate::auth))
+        .layer(middleware::from_fn(move |a, r, n| {
+            crate::auth(allow_authorization_fallback, a, r, n)
+        }))
 }

--- a/api/src/tasks.rs
+++ b/api/src/tasks.rs
@@ -1,6 +1,7 @@
 //! Routes related to tasks.
 
 use axum::Router;
+use axum::middleware;
 use axum::routing::get;
 use axum::routing::post;
 
@@ -18,4 +19,5 @@ pub fn router() -> Router<State> {
         // TODO: the path should be `/v1/tasks/{id}:cancel`, but that's not supported until
         // `matchit`` 0.8.6; we're currently on 0.8.4 via `axum`
         .route("/v1/tasks/{id}", post(v1::cancel_task))
+        .layer(middleware::from_fn(crate::auth))
 }

--- a/api/src/tasks/v1.rs
+++ b/api/src/tasks/v1.rs
@@ -6,8 +6,8 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::bail;
+use axum::Extension;
 use axum::extract::State;
-use axum::http::StatusCode;
 use glob::Pattern;
 use planetary_db::format_log_message;
 use planetary_server::Error;
@@ -22,6 +22,7 @@ use tes::v1::types::requests::GetTaskParams;
 use tes::v1::types::requests::ListTasksParams;
 use tes::v1::types::requests::MAX_PAGE_SIZE;
 use tes::v1::types::requests::Task as RequestTask;
+use tes::v1::types::requests::View;
 use tes::v1::types::responses::CreatedTask;
 use tes::v1::types::responses::ListTasks;
 use tes::v1::types::responses::TaskResponse;
@@ -35,6 +36,7 @@ use tokio_retry2::Retry;
 use tokio_retry2::RetryError;
 use url::Url;
 
+use crate::Username;
 use crate::notify_retry;
 use crate::retry_durations;
 
@@ -260,6 +262,7 @@ fn validate_task(task: &RequestTask) -> Result<()> {
 
 /// The `POST /tasks` route.
 pub async fn create_task(
+    Extension(username): Extension<Username>,
     State(state): State<crate::State>,
     Json(task): Json<RequestTask>,
 ) -> ServerResponse<Json<CreatedTask>> {
@@ -267,7 +270,7 @@ pub async fn create_task(
         return Err(Error::bad_request(e.to_string()));
     }
 
-    let id = state.database.insert_task(&task).await?;
+    let id = state.database.insert_task(&username.0, &task).await?;
 
     // Notify an orchestrator service to start the task
     Retry::spawn_notify(
@@ -306,6 +309,7 @@ pub async fn create_task(
 
 /// The `GET /tasks` route.
 pub async fn list_tasks(
+    Extension(username): Extension<Username>,
     Query(params): Query<ListTasksParams>,
     State(state): State<crate::State>,
 ) -> ServerResponse<Json<ListTasks<TaskResponse>>> {
@@ -328,7 +332,7 @@ pub async fn list_tasks(
         ));
     }
 
-    let (tasks, next_page_token) = state.database.get_tasks(params).await?;
+    let (tasks, next_page_token) = state.database.get_tasks(&username.0, params).await?;
 
     Ok(Json(ListTasks {
         tasks,
@@ -339,20 +343,44 @@ pub async fn list_tasks(
 /// The `GET /tasks/:id` route.
 pub async fn get_task(
     Path(id): Path<String>,
+    Extension(username): Extension<Username>,
     Query(params): Query<GetTaskParams>,
     State(state): State<crate::State>,
 ) -> ServerResponse<Json<TaskResponse>> {
-    let task = state.database.get_task(&id, params).await?;
+    let task = state.database.get_task(&username.0, &id, params).await?;
     Ok(Json(task))
 }
 
 /// The `POST /tasks/:id:cancel` route.
 pub async fn cancel_task(
     Path(id): Path<String>,
+    Extension(username): Extension<Username>,
     State(state): State<crate::State>,
 ) -> ServerResponse<Json<serde_json::Value>> {
     // TODO: remove this once `matchit` 0.8.6 can be used
     let id = id.strip_suffix(":cancel").ok_or_else(Error::not_found)?;
+
+    // Check that the task is currently in a running state
+    // This also ensures that the task is associated with the request's user
+    let task = state
+        .database
+        .get_task(
+            &username.0,
+            id,
+            GetTaskParams {
+                view: View::Minimal,
+            },
+        )
+        .await?;
+    if !task
+        .as_minimal()
+        .expect("should be a minimal task")
+        .state
+        .unwrap_or_default()
+        .is_executing()
+    {
+        return Err(Error::not_cancelable());
+    }
 
     // Mark the task as canceling
     if !state
@@ -366,10 +394,7 @@ pub async fn cancel_task(
         )
         .await?
     {
-        return Err(Error {
-            status: StatusCode::BAD_REQUEST,
-            message: "task is not in a cancelable state".into(),
-        });
+        return Err(Error::not_cancelable());
     }
 
     // Notify the orchestrator service to cancel the task

--- a/chart/examples/development.yaml
+++ b/chart/examples/development.yaml
@@ -1,4 +1,4 @@
-# This file is used to install the Planetary chart into a "staging" cluster.
+# This file is used to install the Planetary chart into a "development" cluster.
 # See README.md for a walkthrough on installing the chart.
 api:
   replicas: 1
@@ -6,14 +6,14 @@ api:
   log: info
   image:
     name: stjude-rust-labs/planetary-api
-    tag: staging
+    tag: dev
 
 orchestrator:
   replicas: 1
   log: info
   image:
     name: stjude-rust-labs/planetary-orchestrator
-    tag: staging
+    tag: dev
   storage:
     nfs:
       server: 10.96.85.10
@@ -23,18 +23,18 @@ monitor:
   log: info
   image:
     name: stjude-rust-labs/planetary-monitor
-    tag: staging
+    tag: dev
 
 transporter:
   log: info
   image:
     name: stjude-rust-labs/planetary-transporter
-    tag: staging
+    tag: dev
 
 migration:
   image:
     name: stjude-rust-labs/planetary-migration
-    tag: staging
+    tag: dev
 
 postgresql:
   enabled: true

--- a/chart/examples/staging.yaml
+++ b/chart/examples/staging.yaml
@@ -2,6 +2,7 @@
 # See README.md for a walkthrough on installing the chart.
 api:
   replicas: 1
+  allowAuthorizationFallback: true
   log: info
   image:
     name: stjude-rust-labs/planetary-api

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
               secretKeyRef:
                 name: orchestrator-auth
                 key: api-key
+          - name: ALLOW_AUTHORIZATION_FALLBACK
+            value: "{{ .Values.api.allowAuthorizationFallback }}"
 ---
 # Deployment for the Planetary orchestrator service
 apiVersion: apps/v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -62,6 +62,10 @@ postgresql:
 # implementing the TES API.
 api:
   replicas: 2
+  # By default, only the `X-Forwarded-User` header is respected for API requests
+  # Setting this to true will allow the `Authorization` header to be used as a fallback
+  # when the `X-Forwarded-User` header is not present.
+  allowAuthorizationFallback: false
   image:
     name: ghcr.io/stjude-rust-labs/planetary-api
     tag: null

--- a/db/CHANGELOG.md
+++ b/db/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Added `username` column to `tasks` table to associate tasks with TES API
+  users ([#40](https://github.com/stjude-rust-labs/planetary/pull/40)).
+
 #### Dependencies
 
 * Updated dependencies to latest ([#37](https://github.com/stjude-rust-labs/planetary/pull/37)).

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -150,6 +150,10 @@ pub trait Database: Send + Sync + 'static {
 
     /// Gets a task's template data for use in rendering Kubernetes resource
     /// templates.
+    ///
+    /// NOTE: this database operation does _not_ filter the template data by
+    /// user; it should only be used from internal contexts (e.g. from the
+    /// Orchestrator) where authorization is assumed.
     async fn get_task_template_data(&self, tes_id: &str) -> DatabaseResult<TaskTemplateData>;
 
     /// Gets the TES identifiers of in-progress tasks.

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -14,6 +14,7 @@ use tes::v1::types::requests::ListTasksParams;
 use tes::v1::types::requests::Task as RequestTask;
 use tes::v1::types::responses::OutputFile;
 use tes::v1::types::responses::TaskResponse;
+use tes::v1::types::task::Executor;
 use tes::v1::types::task::Input;
 use tes::v1::types::task::Output;
 use tes::v1::types::task::State;
@@ -90,27 +91,66 @@ pub struct TerminatedContainer<'a> {
     pub exit_code: i32,
 }
 
+/// Represents data used for rendering task resource templates.
+#[derive(Debug, Clone)]
+pub struct TaskTemplateData {
+    /// The TES identifier of the task.
+    pub id: String,
+    /// Whether or not the task is preemptible.
+    pub preemptible: bool,
+    /// The requested CPU cores for the task.
+    ///
+    /// This is `None` when the default CPU cores should be used.
+    pub cpu: Option<i32>,
+    /// The requested memory for the task (in gigabytes).
+    ///
+    /// This is `None` when the default memory should be used.
+    pub memory: Option<f64>,
+    /// The requested disk for the task (in gigabytes).
+    ///
+    /// This is `None` when the default disk size should be used.
+    pub disk: Option<f64>,
+    /// The task's inputs.
+    pub inputs: Vec<Input>,
+    /// The task's outputs.
+    pub outputs: Vec<Output>,
+    /// The task's volumes.
+    pub volumes: Vec<String>,
+    /// The task's executors.
+    pub executors: Vec<Executor>,
+}
+
 /// An abstraction for the planetary database.
 #[async_trait::async_trait]
 pub trait Database: Send + Sync + 'static {
-    /// Inserts a task into the database.
+    /// Inserts a task into the database for the specified user.
     ///
     /// Note: it is expected that the newly inserted task has the `UNKNOWN`
     /// state.
     ///
     /// Returns the generated TES task identifier.
-    async fn insert_task(&self, task: &RequestTask) -> DatabaseResult<String>;
+    async fn insert_task(&self, username: &str, task: &RequestTask) -> DatabaseResult<String>;
 
-    /// Gets a task from the database.
-    async fn get_task(&self, tes_id: &str, params: GetTaskParams) -> DatabaseResult<TaskResponse>;
+    /// Gets a task from the database for the specified user.
+    async fn get_task(
+        &self,
+        username: &str,
+        tes_id: &str,
+        params: GetTaskParams,
+    ) -> DatabaseResult<TaskResponse>;
 
-    /// Gets tasks from the database.
+    /// Gets tasks from the database for the specified user.
     ///
     /// Returns a list of tasks and the page token to use for the next request.
     async fn get_tasks(
         &self,
+        username: &str,
         params: ListTasksParams,
     ) -> DatabaseResult<(Vec<TaskResponse>, Option<String>)>;
+
+    /// Gets a task's template data for use in rendering Kubernetes resource
+    /// templates.
+    async fn get_task_template_data(&self, tes_id: &str) -> DatabaseResult<TaskTemplateData>;
 
     /// Gets the TES identifiers of in-progress tasks.
     ///

--- a/db/src/postgres.rs
+++ b/db/src/postgres.rs
@@ -23,7 +23,7 @@ use secrecy::SecretString;
 use tes::v1::types::requests::DEFAULT_PAGE_SIZE;
 use tes::v1::types::requests::GetTaskParams;
 use tes::v1::types::requests::ListTasksParams;
-use tes::v1::types::requests::Task as TesTask;
+use tes::v1::types::requests::Task as RequestTask;
 use tes::v1::types::requests::View;
 use tes::v1::types::responses::ExecutorLog;
 use tes::v1::types::responses::OutputFile;
@@ -36,6 +36,7 @@ use tracing::info;
 
 use super::Database;
 use super::DatabaseResult;
+use crate::TaskTemplateData;
 use crate::TerminatedContainer;
 
 pub(crate) mod models;
@@ -205,10 +206,10 @@ impl PostgresDatabase {
 
 #[async_trait::async_trait]
 impl Database for PostgresDatabase {
-    async fn insert_task(&self, task: &TesTask) -> DatabaseResult<String> {
+    async fn insert_task(&self, username: &str, task: &RequestTask) -> DatabaseResult<String> {
         use diesel_async::RunQueryDsl;
 
-        let task = models::NewTask::new(task);
+        let task = models::NewTask::new(username, task);
 
         // Insert the task
         let mut conn = self.pool.get().await.map_err(Error::Pool)?;
@@ -221,7 +222,12 @@ impl Database for PostgresDatabase {
         Ok(task.tes_id)
     }
 
-    async fn get_task(&self, tes_id: &str, params: GetTaskParams) -> DatabaseResult<TaskResponse> {
+    async fn get_task(
+        &self,
+        username: &str,
+        tes_id: &str,
+        params: GetTaskParams,
+    ) -> DatabaseResult<TaskResponse> {
         use diesel::*;
         use diesel_async::RunQueryDsl;
 
@@ -231,7 +237,11 @@ impl Database for PostgresDatabase {
             View::Minimal => Ok(TaskResponse::Minimal(
                 schema::tasks::table
                     .select(models::MinimalTask::as_select())
-                    .filter(schema::tasks::tes_id.eq(tes_id))
+                    .filter(
+                        schema::tasks::username
+                            .eq(username)
+                            .and(schema::tasks::tes_id.eq(tes_id)),
+                    )
                     .first(&mut conn)
                     .await
                     .optional()
@@ -242,7 +252,11 @@ impl Database for PostgresDatabase {
             View::Basic => {
                 let task = schema::tasks::table
                     .select(models::BasicTask::as_select())
-                    .filter(schema::tasks::tes_id.eq(tes_id))
+                    .filter(
+                        schema::tasks::username
+                            .eq(username)
+                            .and(schema::tasks::tes_id.eq(tes_id)),
+                    )
                     .first(&mut conn)
                     .await
                     .optional()
@@ -262,7 +276,11 @@ impl Database for PostgresDatabase {
             View::Full => {
                 let task = schema::tasks::table
                     .select(models::FullTask::as_select())
-                    .filter(schema::tasks::tes_id.eq(tes_id))
+                    .filter(
+                        schema::tasks::username
+                            .eq(username)
+                            .and(schema::tasks::tes_id.eq(tes_id)),
+                    )
                     .first(&mut conn)
                     .await
                     .optional()
@@ -282,14 +300,33 @@ impl Database for PostgresDatabase {
         }
     }
 
+    async fn get_task_template_data(&self, tes_id: &str) -> DatabaseResult<TaskTemplateData> {
+        use diesel::*;
+        use diesel_async::RunQueryDsl;
+
+        let mut conn = self.pool.get().await.map_err(Error::Pool)?;
+        Ok(schema::tasks::table
+            .select(models::TaskTemplateData::as_select())
+            .filter(schema::tasks::tes_id.eq(tes_id))
+            .first(&mut conn)
+            .await
+            .optional()
+            .map_err(Error::Diesel)?
+            .ok_or_else(|| Error::TaskNotFound(tes_id.to_string()))?
+            .into())
+    }
+
     async fn get_tasks(
         &self,
+        username: &str,
         params: ListTasksParams,
     ) -> DatabaseResult<(Vec<TaskResponse>, Option<String>)> {
         use diesel::*;
         use diesel_async::RunQueryDsl;
 
         let mut query = schema::tasks::table.into_boxed();
+
+        query = query.filter(schema::tasks::username.eq(username));
 
         // Add the name prefix to the query
         if let Some(prefix) = &params.name_prefix {

--- a/db/src/postgres/migrations/2025-05-12-172231_initial/up.sql
+++ b/db/src/postgres/migrations/2025-05-12-172231_initial/up.sql
@@ -42,7 +42,7 @@ CREATE TABLE tasks (
 -- Create an index on the `name` column for list operations.
 CREATE INDEX idx_tasks_name ON tasks (name text_pattern_ops);
 
--- Create an index on the `user` column for all task operations.
+-- Create an index on the `username` column for all task operations.
 CREATE INDEX idx_tasks_username ON tasks (username);
 
 -- Create an index on the `state` column for list operations.

--- a/db/src/postgres/migrations/2025-05-12-172231_initial/up.sql
+++ b/db/src/postgres/migrations/2025-05-12-172231_initial/up.sql
@@ -16,6 +16,7 @@ CREATE TYPE task_state AS ENUM(
 -- The tasks table.
 CREATE TABLE tasks (
     id SERIAL PRIMARY KEY,
+    username TEXT NOT NULL,
     tes_id TEXT NOT NULL,
     state task_state NOT NULL DEFAULT 'UNKNOWN',
     name TEXT NULL,
@@ -40,6 +41,9 @@ CREATE TABLE tasks (
 
 -- Create an index on the `name` column for list operations.
 CREATE INDEX idx_tasks_name ON tasks (name text_pattern_ops);
+
+-- Create an index on the `user` column for all task operations.
+CREATE INDEX idx_tasks_username ON tasks (username);
 
 -- Create an index on the `state` column for list operations.
 CREATE INDEX idx_tasks_state ON tasks (state);

--- a/db/src/postgres/models.rs
+++ b/db/src/postgres/models.rs
@@ -164,6 +164,8 @@ impl Serialize for TagFilter {
 pub struct NewTask<'a> {
     /// The state of the task.
     pub state: TaskState,
+    /// The username associated with the task.
+    pub username: &'a str,
     /// The generated TES id for the task.
     pub tes_id: String,
     /// The optional name of the new task.
@@ -200,11 +202,12 @@ pub struct NewTask<'a> {
 
 impl<'a> NewTask<'a> {
     /// Constructs a new task model from the given create task request.
-    pub fn new(task: &'a RequestTask) -> Self {
+    pub fn new(username: &'a str, task: &'a RequestTask) -> Self {
         let resources = task.resources.as_ref();
 
         Self {
             state: TaskState::Unknown,
+            username,
             tes_id: format!("{:#}", Alphanumeric::new(20)),
             name: task.name.as_deref(),
             description: task.description.as_deref(),
@@ -460,6 +463,52 @@ impl From<FullTask> for (ResponseTask, Vec<OutputFile>, Vec<String>) {
                 .map(|l| l.into_iter().map(Option::unwrap_or_default).collect())
                 .unwrap_or_default(),
         )
+    }
+}
+
+/// Represents template data of a task.
+#[derive(Debug, Queryable, Selectable, Identifiable)]
+#[diesel(table_name = super::schema::tasks)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct TaskTemplateData {
+    /// The task database identifier.
+    pub id: i32,
+    /// The TES identifier of the task.
+    pub tes_id: String,
+    /// The task inputs.
+    pub inputs: Option<Json<Vec<Input>>>,
+    /// The task outputs.
+    pub outputs: Option<Json<Vec<Output>>>,
+    /// The requested task CPU cores.
+    pub cpu_cores: Option<i32>,
+    /// Whether or not the task may be preemptible.
+    pub preemptible: Option<bool>,
+    /// The requested task memory (in GB).
+    pub ram_gb: Option<f64>,
+    /// The requested task disk (in GB).
+    pub disk_gb: Option<f64>,
+    /// The task executors.
+    pub executors: Json<Vec<Executor>>,
+    /// The requested volumes for the task.
+    pub volumes: Option<Vec<Option<String>>>,
+}
+
+impl From<TaskTemplateData> for crate::TaskTemplateData {
+    fn from(data: TaskTemplateData) -> Self {
+        Self {
+            id: data.tes_id,
+            preemptible: data.preemptible.unwrap_or(false),
+            cpu: data.cpu_cores,
+            memory: data.ram_gb,
+            disk: data.disk_gb,
+            inputs: data.inputs.map(Json::into_inner).unwrap_or_default(),
+            outputs: data.outputs.map(Json::into_inner).unwrap_or_default(),
+            volumes: data
+                .volumes
+                .map(|c| c.into_iter().map(Option::unwrap).collect())
+                .unwrap_or_default(),
+            executors: data.executors.into_inner(),
+        }
     }
 }
 

--- a/db/src/postgres/models.rs
+++ b/db/src/postgres/models.rs
@@ -323,7 +323,7 @@ impl From<BasicTask> for (ResponseTask, Vec<OutputFile>, Vec<String>) {
                 disk_gb: task.disk_gb,
                 zones: task
                     .zones
-                    .map(|z| z.into_iter().map(Option::unwrap).collect()),
+                    .map(|z| z.into_iter().map(Option::unwrap_or_default).collect()),
                 backend_parameters: task.backend_parameters.map(Json::into_inner),
                 backend_parameters_strict: task.backend_parameters_strict,
             })
@@ -350,7 +350,7 @@ impl From<BasicTask> for (ResponseTask, Vec<OutputFile>, Vec<String>) {
                 executors: task.executors.into_inner(),
                 volumes: task
                     .volumes
-                    .map(|z| z.into_iter().map(Option::unwrap).collect()),
+                    .map(|z| z.into_iter().map(Option::unwrap_or_default).collect()),
                 tags: task.tags.map(Json::into_inner),
                 logs: None,
                 creation_time: Some(task.creation_time),
@@ -433,7 +433,7 @@ impl From<FullTask> for (ResponseTask, Vec<OutputFile>, Vec<String>) {
                 disk_gb: task.disk_gb,
                 zones: task
                     .zones
-                    .map(|z| z.into_iter().map(Option::unwrap).collect()),
+                    .map(|z| z.into_iter().map(Option::unwrap_or_default).collect()),
                 backend_parameters: task.backend_parameters.map(Json::into_inner),
                 backend_parameters_strict: task.backend_parameters_strict,
             })
@@ -453,7 +453,7 @@ impl From<FullTask> for (ResponseTask, Vec<OutputFile>, Vec<String>) {
                 executors: task.executors.into_inner(),
                 volumes: task
                     .volumes
-                    .map(|z| z.into_iter().map(Option::unwrap).collect()),
+                    .map(|z| z.into_iter().map(Option::unwrap_or_default).collect()),
                 tags: task.tags.map(Json::into_inner),
                 logs: None,
                 creation_time: Some(task.creation_time),
@@ -505,7 +505,7 @@ impl From<TaskTemplateData> for crate::TaskTemplateData {
             outputs: data.outputs.map(Json::into_inner).unwrap_or_default(),
             volumes: data
                 .volumes
-                .map(|c| c.into_iter().map(Option::unwrap).collect())
+                .map(|c| c.into_iter().map(Option::unwrap_or_default).collect())
                 .unwrap_or_default(),
             executors: data.executors.into_inner(),
         }

--- a/db/src/postgres/schema.rs
+++ b/db/src/postgres/schema.rs
@@ -44,6 +44,7 @@ diesel::table! {
 
     tasks (id) {
         id -> Int4,
+        username -> Text,
         tes_id -> Text,
         state -> TaskState,
         name -> Nullable<Text>,

--- a/orchestrator/src/orchestrator.rs
+++ b/orchestrator/src/orchestrator.rs
@@ -50,8 +50,6 @@ use planetary_server::templating::TASK_LABEL;
 use planetary_server::templating::Template;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use tes::v1::types::requests::GetTaskParams;
-use tes::v1::types::requests::View;
 use tes::v1::types::task::Executor;
 use tes::v1::types::task::State;
 use tokio::pin;
@@ -533,13 +531,8 @@ impl TaskOrchestrator {
         debug!("task `{tes_id}` is starting");
 
         let start = async {
-            // Get the full task for the inputs and outputs
-            let task = self
-                .database
-                .get_task(tes_id, GetTaskParams { view: View::Full })
-                .await?
-                .into_task()
-                .expect("should have full task");
+            // Get the task's template data
+            let data = self.database.get_task_template_data(tes_id).await?;
 
             self.database
                 .append_system_log(
@@ -549,21 +542,15 @@ impl TaskOrchestrator {
                 .await?;
 
             // Serialize the task's inputs
-            serialize_items(
-                inputs_file_path(tes_id),
-                task.inputs.as_deref().unwrap_or_default(),
-            )?;
+            serialize_items(inputs_file_path(tes_id), &data.inputs)?;
 
             // Serialize the task's outputs
-            serialize_items(
-                outputs_file_path(tes_id),
-                task.outputs.as_deref().unwrap_or_default(),
-            )?;
+            serialize_items(outputs_file_path(tes_id), &data.outputs)?;
 
             // Create the task's resources from the template
             for mut resource in
                 self.template
-                    .render(&task, &self.discovery, &self.tasks_namespace, |e| {
+                    .render(&data, &self.discovery, &self.tasks_namespace, |e| {
                         format_executor_script(e)
                     })?
             {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -95,23 +95,23 @@ pub struct Error {
 
 impl Error {
     /// Returns a "not found" JSON error response.
-    pub fn not_found() -> Error {
-        Error {
+    pub fn not_found() -> Self {
+        Self {
             status: StatusCode::NOT_FOUND,
             message: "the requested resource was not found".to_string(),
         }
     }
 
     /// Returns a "bad request" JSON error response.
-    pub fn bad_request(message: impl Into<String>) -> Error {
-        Error {
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self {
             status: StatusCode::BAD_REQUEST,
             message: message.into(),
         }
     }
 
     /// Returns a "forbidden" JSON error response.
-    pub fn forbidden() -> Error {
+    pub fn forbidden() -> Self {
         Self {
             status: StatusCode::FORBIDDEN,
             message: StatusCode::FORBIDDEN.to_string(),
@@ -119,10 +119,18 @@ impl Error {
     }
 
     /// Returns an "internal server error" JSON error response.
-    pub fn internal() -> Error {
+    pub fn internal() -> Self {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             message: StatusCode::INTERNAL_SERVER_ERROR.to_string(),
+        }
+    }
+
+    /// Returns a "task is not cancelable" error.
+    pub fn not_cancelable() -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: "task is not in a cancelable state".into(),
         }
     }
 }

--- a/server/src/templating.rs
+++ b/server/src/templating.rs
@@ -15,13 +15,13 @@ use kube::api::GroupVersionKind;
 use kube::discovery::ApiCapabilities;
 use kube::discovery::Scope;
 use kube::runtime::reflector::Lookup;
+use planetary_db::TaskTemplateData;
 use serde::Deserialize as _;
 use serde_yaml_ng::Deserializer;
 use tera::Context;
 use tera::Map;
 use tera::Tera;
 use tera::Value;
-use tes::v1::types::responses::Task;
 use tes::v1::types::task::Executor;
 
 /// The orchestrator id label.
@@ -98,23 +98,18 @@ impl Template {
     /// with a restart policy of `Never`.
     pub fn render(
         &self,
-        task: &Task,
+        data: &TaskTemplateData,
         discovery: &Discovery,
         namespace: &str,
         script: impl Fn(&Executor) -> Result<String>,
     ) -> Result<Vec<TaskResource>> {
         let rendered = self
             .0
-            .render(TEMPLATE_NAME, &Self::create_context(task, script)?)
+            .render(TEMPLATE_NAME, &Self::create_context(data, script)?)
             .context("failed to render task resource template")?;
 
-        let id = task
-            .id
-            .as_deref()
-            .context("task does not have an identifier")?;
-
         let resources = serde_yaml_ng::Deserializer::from_str(&rendered)
-            .map(|de| self.deserialize_object(id, discovery, namespace, de))
+            .map(|de| self.deserialize_object(&data.id, discovery, namespace, de))
             .collect::<Result<Vec<_>>>()?;
 
         // Ensure there is exactly one pod that has a restart policy of `Never`
@@ -156,9 +151,16 @@ impl Template {
     ) -> Result<Vec<TaskResource>> {
         // Render the template using only the identifier of the task
         self.render(
-            &Task {
-                id: Some(id.into()),
-                ..Default::default()
+            &TaskTemplateData {
+                id: id.into(),
+                preemptible: false,
+                cpu: None,
+                memory: None,
+                disk: None,
+                inputs: Default::default(),
+                outputs: Default::default(),
+                volumes: Default::default(),
+                executors: Default::default(),
             },
             discovery,
             namespace,
@@ -173,7 +175,7 @@ impl Template {
     ///
     /// Returns an error if the task was invalid.
     fn create_context(
-        task: &Task,
+        data: &TaskTemplateData,
         script: impl Fn(&Executor) -> Result<String>,
     ) -> Result<Context> {
         /// Helper for inserting items into the context.
@@ -185,35 +187,18 @@ impl Template {
             context.insert(name.into(), value.into());
         }
 
-        let resources = task.resources.as_ref();
-
         let mut context = Map::new();
-        insert(
-            &mut context,
-            "id",
-            task.id.as_deref().context("task should have id")?,
-        );
-        insert(
-            &mut context,
-            "preemptible",
-            resources.and_then(|r| r.preemptible).unwrap_or(false),
-        );
+        insert(&mut context, "id", data.id.as_str());
+        insert(&mut context, "preemptible", data.preemptible);
 
         // Set the requested resources
-        insert(
-            &mut context,
-            "cpu",
-            resources.and_then(|r| r.cpu_cores).unwrap_or(DEFAULT_CPU),
-        );
+        insert(&mut context, "cpu", data.cpu.unwrap_or(DEFAULT_CPU));
         insert(
             &mut context,
             "memory",
             format!(
                 "{memory}G",
-                memory = resources
-                    .and_then(|r| r.ram_gb)
-                    .unwrap_or(DEFAULT_MEMORY)
-                    .ceil()
+                memory = data.memory.unwrap_or(DEFAULT_MEMORY).ceil()
             ),
         );
         insert(
@@ -221,42 +206,23 @@ impl Template {
             "disk",
             format!(
                 "{disk}G",
-                disk = resources
-                    .and_then(|r| r.disk_gb)
-                    .unwrap_or(0.0)
-                    .max(DEFAULT_STORAGE_SIZE)
+                disk = data.disk.unwrap_or(0.0).max(DEFAULT_STORAGE_SIZE)
             ),
         );
 
         // Set the inputs
-        let inputs: Vec<Value> = task
-            .inputs
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            .map(|i| i.path.clone().into())
-            .collect();
+        let inputs: Vec<Value> = data.inputs.iter().map(|i| i.path.clone().into()).collect();
         insert(&mut context, "inputs", inputs);
 
         // Set the outputs
-        let outputs: Vec<Value> = task
-            .outputs
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            .map(|o| o.path.clone().into())
-            .collect();
+        let outputs: Vec<Value> = data.outputs.iter().map(|o| o.path.clone().into()).collect();
         insert(&mut context, "outputs", outputs);
 
         // Set the volumes
-        insert(
-            &mut context,
-            "volumes",
-            task.volumes.as_deref().unwrap_or_default(),
-        );
+        insert(&mut context, "volumes", data.volumes.as_slice());
 
         // Set the executors
-        let executors: Vec<Value> = task
+        let executors: Vec<Value> = data
             .executors
             .iter()
             .map(|e| {


### PR DESCRIPTION
This PR implements associating tasks with usernames so that requests to the TES API server are delimited by user.

With these changes, the TES API server expects an `X-Forwarded-User` or a username to be present in a basic `Authorization` header.

The server does no actual authentication; it is expected that an upstream authentication proxy is being used that will authenticate the request and forward the request to the API server with the `X-Forwarded-User` header set.

If a request is not associated with a username, a 403 error response is returned.

To facilitate this feature, a `username` string column was added to the `tasks` table. This is populated with the username when the task is created. The `GetTask` and `CancelTask` operations will return a 404 response if the request's username does not match the task's username column.

The `ListTasks` operation will filter the task list based on the username in the request.

A middleware function was added to the `tasks` route that ensures a username header is present.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

Repository specific checklist:

- [x] If you update the supported TES version, you should change the version at
      `planetary::server::TES_VERSION`.
- [x] Make sure that (a) none of the changes conflict with information we lay 
      out in the "Security Notice" section of the `README.md` and (b) anything
      that needs to be added to that section is added.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
