### PR TITLE
feat: implement "local" storage for tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ inherently available to tasks and, therefore without a configured "local"
 shared volume, task pods would have only ephemeral container storage for
 resolving `file://` schemed URLs.
 
-To assist in a unified local file system, Cluster administrators can configure
+To assist in a unified local file system, cluster administrators can configure
 Planetary to use a shared volume that is automatically used as the storage for
 `file://` schemed inputs and outputs.
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Local input and output files aren't copied to and from cloud storage by the
 Planetary transporter, but instead are directly mounted at the requested paths
 into the executor containers.
 
-However, the transporter still needs access to the local shared volume to ensure
+The transporter still needs access to the local shared volume to ensure
 specified inputs exist and also to create the specified outputs at their
 expected locations.
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ root. For example, an input with URL `file:///foo/bar.txt` will be treated as
 `$ROOT/foo/bar.txt`, where $ROOT is the path at which the `local.storage`
 volume mounts.
 
-It is strongly recommended that the local storage be associated ***only*** for
+It is strongly recommended that the local storage be scoped ***only*** to
 the user of the task. That can be accomplished by using the `{{ username }}`
 value in the task resource template.
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,38 @@ Planetary supports the following cloud storage services:
 See the [`transporter.storage` Helm chart values](./chart/values.yaml) for
 configuring a Planetary deployment.
 
+### Local Inputs and Outputs
+
+TES API clients may specify inputs and outputs with a `file://` schemed URL to
+indicate a desire to access a "local" input or output.
+
+Due to the isolation of pods in Kubernetes, a shared file system is not
+inherently available to tasks and, therefore without a configured "local"
+shared volume, task pods would have only ephemeral container storage for
+resolving `file://` schemed URLs.
+
+To assist in a unified local file system, Cluster administrators can configure
+Planetary to use a shared volume that is automatically used as the storage for
+`file://` schemed inputs and outputs.
+
+An input or output using a `file://` schemed URL is considered to be a path
+relative to the root of the local shared volume. For example, if the shared
+local volume is an NFS share at path `/local/$USERNAME`, an input of `file:///mydir/myfile.txt`
+would map to the actual share path of `/local/$USERNAME/mydir/myfile.txt`
+(note: input and output URLs may not contain `..` parent directory references).
+
+Local input and output files aren't copied to and from cloud storage by the
+Planetary transporter, but instead are directly mounted at the requested paths
+into the executor containers.
+
+However, the transporter still needs access to the local shared volume to ensure
+specified inputs exist and also to create the specified outputs at their
+expected locations.
+
+If support for local storage isn't necessary, use an `emptyDir` volume for the
+shared storage or remove the volume and mounts from the task pod definition in
+the task resource template.
+
 ### Task Execution
 
 Planetary runs each TES task by evaluating a template file for creating

--- a/README.md
+++ b/README.md
@@ -255,35 +255,30 @@ configuring a Planetary deployment.
 
 ### Local Inputs and Outputs
 
-TES API clients may specify inputs and outputs with a `file://` schemed URL to
-indicate a desire to access a "local" input or output.
+When the Helm chart is supplied a value for `local.storage`, Planetary will use
+the specified volume for "local" inputs and outputs. When a value is not
+supplied (the default), support for local inputs and outputs is disabled.
 
-Due to the isolation of pods in Kubernetes, a shared file system is not
-inherently available to tasks and, therefore without a configured "local"
-shared volume, task pods would have only ephemeral container storage for
-resolving `file://` schemed URLs.
+An input or output is considered "local" if its URL uses the `file://` scheme.
 
-To assist in a unified local file system, cluster administrators can configure
-Planetary to use a shared volume that is automatically used as the storage for
-`file://` schemed inputs and outputs.
+Unlike other URL schemes, local inputs are not downloaded from cloud storage
+and local outputs are not uploaded to cloud storage. Instead they are directly
+accessed by the task from the local storage volume.
 
-An input or output using a `file://` schemed URL is considered to be a path
-relative to the root of the local shared volume. For example, if the shared
-local volume is an NFS share at path `/local/$USERNAME`, an input of `file:///mydir/myfile.txt`
-would map to the actual share path of `/local/$USERNAME/mydir/myfile.txt`
-(note: input and output URLs may not contain `..` parent directory references).
+Local inputs and outputs will not count towards the requested disk size for the
+task as they are not copied to the task's storage volume.
 
-Local input and output files aren't copied to and from cloud storage by the
-Planetary transporter, but instead are directly mounted at the requested paths
-into the executor containers.
+The path specified in the URL is treated as relative to the configured volume
+root. For example, an input with URL `file:///foo/bar.txt` will be treated as
+`$ROOT/foo/bar.txt`, where $ROOT is the path at which the `local.storage`
+volume mounts.
 
-The transporter still needs access to the local shared volume to ensure
-specified inputs exist and also to create the specified outputs at their
-expected locations.
+It is strongly recommended that the local storage be associated ***only*** for
+the user of the task. That can be accomplished by using the `{{ username }}`
+value in the task resource template.
 
-If support for local storage isn't necessary, use an `emptyDir` volume for the
-shared storage or remove the volume and mounts from the task pod definition in
-the task resource template.
+See an example of using an NFS share to provide per-user local storage in the
+[development deployment](chart/examples/development.yaml).
 
 ### Task Execution
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added support for local (file://) inputs and outputs ([#41](https://github.com/stjude-rust-labs/planetary/pull/41)).
 * Added support for the `X-Forwarded-User` header for respecting the user
   associated with TES API requests ([#40](https://github.com/stjude-rust-labs/planetary/pull/40)).
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -111,6 +111,8 @@ struct State {
     database: Arc<dyn Database>,
     /// The orchestrator service information.
     orchestrator: Arc<OrchestratorServiceInfo>,
+    /// Whether or not to allow `file://` URLs for task inputs and outputs.
+    allow_file_urls: bool,
 }
 
 impl State {
@@ -121,6 +123,7 @@ impl State {
         database: Arc<dyn Database>,
         orchestrator_url: Url,
         orchestrator_api_key: SecretString,
+        allow_file_urls: bool,
     ) -> Self {
         Self {
             client: Arc::new(Client::new()),
@@ -130,6 +133,7 @@ impl State {
                 url: orchestrator_url,
                 api_key: orchestrator_api_key,
             }),
+            allow_file_urls,
         }
     }
 }
@@ -163,6 +167,9 @@ pub struct Server {
 
     /// Whether or not to allow fallback to the `Authorization` header.
     allow_authorization_fallback: bool,
+
+    /// Whether or not to allow `file://` URLs for task inputs and outputs.
+    allow_file_urls: bool,
 }
 
 impl<S: server_builder::State> ServerBuilder<S> {
@@ -201,6 +208,7 @@ impl Server {
             self.database,
             self.orchestrator_url,
             self.orchestrator_api_key,
+            self.allow_file_urls,
         );
 
         server.run(state, shutdown).await?;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -161,6 +161,10 @@ pub struct Args {
     /// By default, only the `X-Forwarded-User` header is checked.
     #[clap(long, env)]
     allow_authorization_fallback: bool,
+
+    /// Whether or not to allow `file://` URLs for task inputs and outputs.
+    #[clap(long, env)]
+    allow_file_urls: bool,
 }
 
 impl Args {
@@ -241,6 +245,7 @@ pub async fn main() -> anyhow::Result<()> {
         .orchestrator_url(args.orchestrator_url)
         .orchestrator_api_key(args.orchestrator_api_key)
         .allow_authorization_fallback(args.allow_authorization_fallback)
+        .allow_file_urls(args.allow_file_urls)
         .info(ServiceInfo::try_from(args.service_info)?)
         .build()
         .run(terminate())

--- a/api/src/tasks/v1.rs
+++ b/api/src/tasks/v1.rs
@@ -41,25 +41,24 @@ use crate::notify_retry;
 use crate::retry_durations;
 
 /// Determines if the given URL is supported by Planetary.
-fn ensure_supported_url(url: &Url, kind: &str) -> Result<()> {
+fn ensure_supported_url(url: &str, kind: &str) -> Result<()> {
+    let url: Url = url
+        .parse()
+        .map_err(|_| anyhow!("invalid {kind} URL `{url}`"))?;
+
     match url.scheme() {
-        "https" | "az" | "s3" | "gs" | "file" => {}
+        "file" | "http" | "https" | "az" | "s3" | "gs" => {}
         scheme => bail!("{kind} URL `{url}` uses unsupported scheme `{scheme}`"),
     }
 
-    // For file URLs, the path must be absolute and not contain any `..`
+    // File URLs are required to be convertible to a file path
     if url.scheme() == "file" {
         let path = url
             .to_file_path()
             .map_err(|_| anyhow!("invalid {kind} file URL `{url}`"))?;
 
-        if !path.is_absolute() {
-            bail!("path specified by {kind} file URL `{url}` must be absolute");
-        }
-
-        // The path cannot contain `..` segments
-        if path.components().any(|c| matches!(c, Component::ParentDir)) {
-            bail!("{kind} file URL `{url}` cannot contain `..` path segments");
+        if path.into_os_string().into_string().is_err() {
+            bail!("{kind} URL `{url}` cannot be represented in UTF-8");
         }
     }
 
@@ -87,12 +86,8 @@ fn validate_task(task: &RequestTask) -> Result<()> {
         match (&input.url, &input.content) {
             (None, None) => bail!("input URL is required"),
             (Some(url), None) => {
-                let url: Url = url
-                    .parse()
-                    .map_err(|_| anyhow!("invalid input URL `{url}`"))?;
-
                 // Check for supported URL schemes
-                ensure_supported_url(&url, "input")?;
+                ensure_supported_url(url, "input")?;
             }
             (_, Some(_)) => {
                 // If content is specified, URL is ignored; it must be a file type
@@ -112,30 +107,17 @@ fn validate_task(task: &RequestTask) -> Result<()> {
             bail!("output path `{path}` is not absolute", path = output.path);
         }
 
-        if output.url.is_empty() {
-            bail!("output URL is required");
-        }
-
-        // The URL must parse
-        let url = output
-            .url
-            .parse::<Url>()
-            .map_err(|_| anyhow!("invalid output URL `{url}`", url = output.url))?;
-
-        // Check for supported URL schemes
-        ensure_supported_url(&url, "output")?;
-
-        // The output path cannot be root
-        if output.path == "/" {
-            bail!("output path cannot be `/`");
-        }
-
         // The output path cannot contain `..` segments
         if path.components().any(|c| matches!(c, Component::ParentDir)) {
             bail!(
                 "output path `{path}` cannot contain `..` path segments",
                 path = output.path
             );
+        }
+
+        // The output path cannot be root
+        if output.path == "/" {
+            bail!("output path cannot be `/`");
         }
 
         // If a path prefix was specified, then the output must be a directory
@@ -167,6 +149,9 @@ fn validate_task(task: &RequestTask) -> Result<()> {
                 );
             }
         }
+
+        // Check for supported URL schemes
+        ensure_supported_url(&output.url, "output")?;
 
         Ok(())
     }

--- a/api/src/tasks/v1.rs
+++ b/api/src/tasks/v1.rs
@@ -285,7 +285,7 @@ pub async fn create_task(
     Json(task): Json<RequestTask>,
 ) -> ServerResponse<Json<CreatedTask>> {
     if let Err(e) = validate_task(&task, state.allow_file_urls) {
-        return Err(Error::bad_request(e.to_string()));
+        return Err(Error::bad_request(format!("{e:#}")));
     }
 
     let id = state.database.insert_task(&username.0, &task).await?;

--- a/api/src/tasks/v1.rs
+++ b/api/src/tasks/v1.rs
@@ -41,13 +41,14 @@ use crate::notify_retry;
 use crate::retry_durations;
 
 /// Ensures that the given URL is supported by Planetary.
-fn ensure_supported_url(url: &str, kind: &str) -> Result<()> {
+fn ensure_supported_url(url: &str, kind: &str, allow_file_urls: bool) -> Result<()> {
     let url: Url = url
         .parse()
         .map_err(|_| anyhow!("invalid {kind} URL `{url}`"))?;
 
     match url.scheme() {
-        "file" | "http" | "https" | "az" | "s3" | "gs" => {}
+        "http" | "https" | "az" | "s3" | "gs" => {}
+        "file" if allow_file_urls => {}
         scheme => bail!("{kind} URL `{url}` uses unsupported scheme `{scheme}`"),
     }
 
@@ -71,10 +72,10 @@ fn ensure_supported_url(url: &str, kind: &str) -> Result<()> {
 }
 
 /// Performs validation on the request.
-fn validate_task(task: &RequestTask) -> Result<()> {
+fn validate_task(task: &RequestTask, allow_file_urls: bool) -> Result<()> {
     use std::path::Path;
 
-    fn validate_input(input: &Input) -> Result<()> {
+    fn validate_input(input: &Input, allow_file_urls: bool) -> Result<()> {
         let path = Path::new(&input.path);
         if !path.is_absolute() {
             bail!("input path `{path}` is not absolute", path = input.path);
@@ -92,7 +93,7 @@ fn validate_task(task: &RequestTask) -> Result<()> {
             (None, None) => bail!("input URL is required"),
             (Some(url), None) => {
                 // Check for supported URL schemes
-                ensure_supported_url(url, "input")?;
+                ensure_supported_url(url, "input", allow_file_urls)?;
             }
             (_, Some(_)) => {
                 // If content is specified, URL is ignored; it must be a file type
@@ -105,7 +106,7 @@ fn validate_task(task: &RequestTask) -> Result<()> {
         Ok(())
     }
 
-    fn validate_output(output: &Output) -> Result<()> {
+    fn validate_output(output: &Output, allow_file_urls: bool) -> Result<()> {
         // The output path must be absolute
         let path = Path::new(&output.path);
         if !path.is_absolute() {
@@ -156,7 +157,7 @@ fn validate_task(task: &RequestTask) -> Result<()> {
         }
 
         // Check for supported URL schemes
-        ensure_supported_url(&output.url, "output")?;
+        ensure_supported_url(&output.url, "output", allow_file_urls)?;
 
         Ok(())
     }
@@ -251,11 +252,11 @@ fn validate_task(task: &RequestTask) -> Result<()> {
     }
 
     for input in task.inputs.as_deref().unwrap_or_default() {
-        validate_input(input)?;
+        validate_input(input, allow_file_urls)?;
     }
 
     for output in task.outputs.as_deref().unwrap_or_default() {
-        validate_output(output)?;
+        validate_output(output, allow_file_urls)?;
     }
 
     if task.executors.is_empty() {
@@ -283,7 +284,7 @@ pub async fn create_task(
     State(state): State<crate::State>,
     Json(task): Json<RequestTask>,
 ) -> ServerResponse<Json<CreatedTask>> {
-    if let Err(e) = validate_task(&task) {
+    if let Err(e) = validate_task(&task, state.allow_file_urls) {
         return Err(Error::bad_request(e.to_string()));
     }
 

--- a/api/src/tasks/v1.rs
+++ b/api/src/tasks/v1.rs
@@ -51,11 +51,16 @@ fn ensure_supported_url(url: &str, kind: &str) -> Result<()> {
         scheme => bail!("{kind} URL `{url}` uses unsupported scheme `{scheme}`"),
     }
 
-    // File URLs are required to be convertible to a file path
+    // File URLs are required to be convertible to a UTF-8 file path with no
+    // parent-directory segments
     if url.scheme() == "file" {
         let path = url
             .to_file_path()
             .map_err(|_| anyhow!("invalid {kind} file URL `{url}`"))?;
+
+        if path.components().any(|c| matches!(c, Component::ParentDir)) {
+            bail!("{kind} file URL `{url}` cannot contain `..` path segments");
+        }
 
         if path.into_os_string().into_string().is_err() {
             bail!("{kind} URL `{url}` cannot be represented in UTF-8");

--- a/api/src/tasks/v1.rs
+++ b/api/src/tasks/v1.rs
@@ -40,7 +40,7 @@ use crate::Username;
 use crate::notify_retry;
 use crate::retry_durations;
 
-/// Determines if the given URL is supported by Planetary.
+/// Ensures that the given URL is supported by Planetary.
 fn ensure_supported_url(url: &str, kind: &str) -> Result<()> {
     let url: Url = url
         .parse()

--- a/api/src/tasks/v1.rs
+++ b/api/src/tasks/v1.rs
@@ -40,13 +40,48 @@ use crate::Username;
 use crate::notify_retry;
 use crate::retry_durations;
 
+/// Determines if the given URL is supported by Planetary.
+fn ensure_supported_url(url: &Url, kind: &str) -> Result<()> {
+    match url.scheme() {
+        "https" | "az" | "s3" | "gs" | "file" => {}
+        scheme => bail!("{kind} URL `{url}` uses unsupported scheme `{scheme}`"),
+    }
+
+    // For file URLs, the path must be absolute and not contain any `..`
+    if url.scheme() == "file" {
+        let path = url
+            .to_file_path()
+            .map_err(|_| anyhow!("invalid {kind} file URL `{url}`"))?;
+
+        if !path.is_absolute() {
+            bail!("path specified by {kind} file URL `{url}` must be absolute");
+        }
+
+        // The path cannot contain `..` segments
+        if path.components().any(|c| matches!(c, Component::ParentDir)) {
+            bail!("{kind} file URL `{url}` cannot contain `..` path segments");
+        }
+    }
+
+    Ok(())
+}
+
 /// Performs validation on the request.
 fn validate_task(task: &RequestTask) -> Result<()> {
     use std::path::Path;
 
     fn validate_input(input: &Input) -> Result<()> {
-        if !Path::new(&input.path).is_absolute() {
+        let path = Path::new(&input.path);
+        if !path.is_absolute() {
             bail!("input path `{path}` is not absolute", path = input.path);
+        }
+
+        // The input path cannot contain `..` segments
+        if path.components().any(|c| matches!(c, Component::ParentDir)) {
+            bail!(
+                "input path `{path}` cannot contain `..` path segments",
+                path = input.path
+            );
         }
 
         match (&input.url, &input.content) {
@@ -56,12 +91,8 @@ fn validate_task(task: &RequestTask) -> Result<()> {
                     .parse()
                     .map_err(|_| anyhow!("invalid input URL `{url}`"))?;
 
-                match url.scheme() {
-                    "http" | "https" | "az" | "s3" | "gs" => {
-                        // Supported
-                    }
-                    scheme => bail!("input URL `{url}` uses unsupported scheme `{scheme}`"),
-                }
+                // Check for supported URL schemes
+                ensure_supported_url(&url, "input")?;
             }
             (_, Some(_)) => {
                 // If content is specified, URL is ignored; it must be a file type
@@ -75,6 +106,12 @@ fn validate_task(task: &RequestTask) -> Result<()> {
     }
 
     fn validate_output(output: &Output) -> Result<()> {
+        // The output path must be absolute
+        let path = Path::new(&output.path);
+        if !path.is_absolute() {
+            bail!("output path `{path}` is not absolute", path = output.path);
+        }
+
         if output.url.is_empty() {
             bail!("output URL is required");
         }
@@ -85,18 +122,8 @@ fn validate_task(task: &RequestTask) -> Result<()> {
             .parse::<Url>()
             .map_err(|_| anyhow!("invalid output URL `{url}`", url = output.url))?;
 
-        match url.scheme() {
-            "https" | "az" | "s3" | "gs" => {
-                // Supported
-            }
-            scheme => bail!("output URL `{url}` uses unsupported scheme `{scheme}`"),
-        }
-
-        // The output path must be absolute
-        let path = Path::new(&output.path);
-        if !path.is_absolute() {
-            bail!("output path `{path}` is not absolute", path = output.path);
-        }
+        // Check for supported URL schemes
+        ensure_supported_url(&url, "output")?;
 
         // The output path cannot be root
         if output.path == "/" {

--- a/api/src/tasks/v1.rs
+++ b/api/src/tasks/v1.rs
@@ -44,7 +44,7 @@ use crate::retry_durations;
 fn ensure_supported_url(url: &str, kind: &str, allow_file_urls: bool) -> Result<()> {
     let url: Url = url
         .parse()
-        .map_err(|_| anyhow!("invalid {kind} URL `{url}`"))?;
+        .with_context(|| format!("invalid {kind} URL `{url}`"))?;
 
     match url.scheme() {
         "http" | "https" | "az" | "s3" | "gs" => {}
@@ -55,9 +55,9 @@ fn ensure_supported_url(url: &str, kind: &str, allow_file_urls: bool) -> Result<
     // File URLs are required to be convertible to a UTF-8 file path with no
     // parent-directory segments
     if url.scheme() == "file" {
-        let path = url
-            .to_file_path()
-            .map_err(|_| anyhow!("invalid {kind} file URL `{url}`"))?;
+        let path = url.to_file_path().map_err(|_| {
+            anyhow!("invalid {kind} file URL `{url}`: host must be empty or `localhost`")
+        })?;
 
         if path.components().any(|c| matches!(c, Component::ParentDir)) {
             bail!("{kind} file URL `{url}` cannot contain `..` path segments");

--- a/chart/CHANGELOG.md
+++ b/chart/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Added `local.storage` to support local inputs and outputs ([#41](https://github.com/stjude-rust-labs/planetary/pull/41)).
 * Added `transporter.storage.azure` values for Azure Storage authentication ([#27](https://github.com/stjude-rust-labs/planetary/pull/27)).
 * Added a 15 minute TTL on the migration job ([#25](https://github.com/stjude-rust-labs/planetary/pull/25)).
 * Addes dynamic egress network policy additions for cloud and user exceptions ([#34](https://github.com/stjude-rust-labs/planetary/pull/34)).

--- a/chart/examples/development.yaml
+++ b/chart/examples/development.yaml
@@ -42,11 +42,13 @@ postgresql:
     limits:
       memory: '8Gi'
 
+# Enable support for "local" (file://) URLs using NFS-backed storage. 
+# This will segment the local storage by user name so that task pods
+# can only access the files for the user related to the task.
 local:
   storage:
     nfs:
       server: 10.96.85.10
-      # By default, local storage is segmented by user name
       path: /local/{{ `{{ username }}` }}
 
 extra:
@@ -82,19 +84,11 @@ extra:
         securityContext:
           fsGroup: 1000
         containers:
-        - name: create-local-dir
+        - name: create-dirs
           securityContext:
             runAsUser: 1000
           image: alpine:latest
-          command: ["mkdir",  "-p", "/mnt/nfs/local"]
-          volumeMounts:
-          - name: nfs
-            mountPath: /mnt/nfs
-        - name: create-orchestrator-dir
-          securityContext:
-            runAsUser: 1000
-          image: alpine:latest
-          command: ["mkdir",  "-p", "/mnt/nfs/orchestrator"]
+          command: ["mkdir",  "-p", "/mnt/nfs/local", "/mnt/nfs/orchestrator"]
           volumeMounts:
           - name: nfs
             mountPath: /mnt/nfs

--- a/chart/examples/development.yaml
+++ b/chart/examples/development.yaml
@@ -17,7 +17,7 @@ orchestrator:
   storage:
     nfs:
       server: 10.96.85.10
-      path: /
+      path: /orchestrator
 
 monitor:
   log: info
@@ -42,6 +42,13 @@ postgresql:
     limits:
       memory: '8Gi'
 
+local:
+  storage:
+    nfs:
+      server: 10.96.85.10
+      # By default, local storage is segmented by user name
+      path: /local/{{ `{{ username }}` }}
+
 extra:
 # Create an NFS service for the shared storage
 - apiVersion: nfs.krestomat.io/v1alpha1
@@ -59,3 +66,41 @@ extra:
     ganeshaGeneratedNfsScNeeded: false
     # A static cluster IP is required for the service as nodes mount the NFS volume without access to `kube-dns`
     ganeshaServiceClusterIp: 10.96.85.10
+# A job responsible for creating the expected directories for the orchestrator and local shares
+# Without this, the monitor and orchestrator pods won't start 
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: create-nfs-dirs
+    namespace: planetary
+  spec:
+    activeDeadlineSeconds: 60
+    ttlSecondsAfterFinished: 60
+    backoffLimit: 1
+    template:
+      spec:
+        securityContext:
+          fsGroup: 1000
+        containers:
+        - name: create-local-dir
+          securityContext:
+            runAsUser: 1000
+          image: alpine:latest
+          command: ["mkdir",  "-p", "/mnt/nfs/local"]
+          volumeMounts:
+          - name: nfs
+            mountPath: /mnt/nfs
+        - name: create-orchestrator-dir
+          securityContext:
+            runAsUser: 1000
+          image: alpine:latest
+          command: ["mkdir",  "-p", "/mnt/nfs/orchestrator"]
+          volumeMounts:
+          - name: nfs
+            mountPath: /mnt/nfs
+        restartPolicy: Never
+        volumes:
+        - name: nfs
+          nfs:
+            server: 10.96.85.10
+            path: /

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,5 +1,3 @@
-{{- $storage := .Values.local.storage | required "The `local.storage` value is required." -}}
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +5,7 @@ metadata:
 data:
   # The orchestrator uses this template when creating resources for tasks.
   # See https://keats.github.io/tera for the template syntax.
-  # NOTE: all Tera template tags must be escaped for the Helm chart.
+  # NOTE: all Tera template expression tags (e.g. `{{` and `}}`) must be escaped for the Helm chart.
   task.yaml: |
     # This is the PVC used for the task's `disk` requirement.
     # The task's non-local inputs, non-local outputs, work directory, and
@@ -30,24 +28,24 @@ data:
     metadata:
       name: {{ `{{ id }}` }}
     spec:
-      {{- with .Values.orchestrator.preemptible }}
+      {{ with .Values.orchestrator.preemptible -}}
       # Node selector and toleration to use for preemptible tasks
-      {{ `{%- if preemptible %}` }}
+      {% if preemptible %}
       nodeSelector:
         {{ .nodeSelector.key }}: "{{ .nodeSelector.value }}"
-      tolerations: 
+      tolerations:
         - key: "{{ .toleration.key }}"
           operator: Equal
           value: "{{ .toleration.value }}"
-      {{ `{%- endif %}` }}
-      {{- end }}
+      {% endif %}
+      {{ end -}}
       # Task pods are required to have a `Never` restart policy
       restartPolicy: Never
       initContainers:
       # The first init container is responsible for downloading inputs and creating empty outputs to mount
       - name: inputs
         image: "{{ .Values.transporter.image.name }}:{{ .Values.transporter.image.tag | default .Chart.AppVersion }}"
-        args: ["-v", "--mode", "inputs", "--orchestrator-dir", "/mnt/orchestrator", "--inputs-dir", "/mnt/storage/inputs", "--outputs-dir", "/mnt/storage/outputs", "--local-dir", "/mnt/local", {{ `{{ id | json_encode }}` }}]
+        args: ["-v", "--mode", "inputs", "--orchestrator-dir", "/mnt/orchestrator", "--inputs-dir", "/mnt/storage/inputs", "--outputs-dir", "/mnt/storage/outputs", {{ if .Values.local.storage }}"--local-dir", "/mnt/local",{{ end }} {{ `{{ id | json_encode }}` }}]
         envFrom:
         - secretRef:
             name: azure-storage-credentials
@@ -64,8 +62,10 @@ data:
         volumeMounts:
         - name: storage
           mountPath: /mnt/storage
+        {{ if .Values.local.storage -}}
         - name: local
           mountPath: /mnt/local
+        {{ end -}}
         - name: orchestrator-storage
           mountPath: /mnt/orchestrator
           readOnly: true
@@ -75,17 +75,17 @@ data:
             cpu: "{{ .Values.transporter.cpu }}"
             memory: "{{ .Values.transporter.memory }}"
       # The remaining init containers are the task's executors
-      {{ `{%- for executor in executors %}` }}
+      {% for executor in executors %}
       - name: executor-{{ `{{ loop.index0 }}` }}
         image: {{ `{{ executor.image }}` }}
         command: ["/bin/sh"]
         args: ["-c", {{ `{{ executor.script | json_encode }}` }}]
         workingDir: {{ `{{ executor.workdir }}` }}
         env:
-        {{ `{%- for key, value in executor.env %}` }}
+        {% for key, value in executor.env %}
         - name: {{ `{{ key }}` }}
           value: {{ `{{ value }}` }}
-        {{ `{%- endfor %}` }}
+        {% endfor %}
         resources:
           requests:
             cpu: {{ `"{{ cpu }}"` }}
@@ -94,29 +94,35 @@ data:
           - name: storage
             mountPath: /tmp
             subPath: tmp
-          {{ `{%- for volume in volumes %}` }}
+          {% for volume in volumes %}
           - name: storage
             mountPath: {{ `{{ volume }}` }}
             subPath: volumes/{{ `{{ loop.index0 }}` }}
-          {{ `{%- endfor -%}` }}
-          {{ `{%- for input in inputs %}` }}
-          - name: {{ `{% if input.local_path %}local{% else %}storage{% endif %}` }}
+          {% endfor %}
+          {% for input in inputs %}
+          {{- if not .Values.local.storage }}
+          {% if input.local_path %}{% continue %}{% endif %}
+          {{ end -}}
+          - name: {% if input.local_path %}local{% else %}storage{% endif %}
             mountPath: {{ `{{ input.path }}` }}
-            subPath: {{ `{% if input.local_path %}{{ input.local_path }}{% else %}inputs/{{loop.index0}}{% endif %}` }}
+            subPath: {% if input.local_path %}{{ `{{ input.local_path }}` }}{% else %}inputs/{{ `{{ loop.index0 }}` }}{% endif %}
             readOnly: true
             recursiveReadOnly: IfPossible
-          {{ `{%- endfor -%}` }}
-          {{ `{%- for output in outputs %}` }}
-          - name: {{ `{% if output.local_path %}local{% else %}storage{% endif %}` }}
+          {% endfor %}
+          {% for output in outputs %}
+          {{- if not .Values.local.storage }}
+          {% if output.local_path %}{% continue %}{% endif %}
+          {{ end -}}
+          - name: {% if output.local_path %}local{% else %}storage{% endif %}
             mountPath: {{ `{{ output.path }}` }}
-            subPath: {{ `{% if output.local_path %}{{ output.local_path }}{% else %}outputs/{{loop.index0}}{% endif %}` }}
-            {{ `{%- endfor -%}` }}
-      {{ `{%- endfor %}` }}
+            subPath: {% if output.local_path %}{{ `{{ output.local_path }}` }}{% else %}outputs/{{ `{{ loop.index0 }}` }}{% endif %}
+          {% endfor %}
+      {% endfor %}
       containers:
       # The primary container of the task pod is responsible for uploading the task's outputs
       - name: outputs
         image: "{{ .Values.transporter.image.name }}:{{ .Values.transporter.image.tag | default .Chart.AppVersion }}"
-        args: ["-v", "--mode", "outputs", "--orchestrator-dir", "/mnt/orchestrator", "--outputs-dir", "/mnt/outputs", "--local-dir", "/mnt/local", {{ `{{ id | json_encode }}` }}]
+        args: ["-v", "--mode", "outputs", "--orchestrator-dir", "/mnt/orchestrator", "--outputs-dir", "/mnt/outputs", {{ if .Values.local.storage }}"--local-dir", "/mnt/local",{{ end }} {{ `{{ id | json_encode }}` }}]
         envFrom:
         - secretRef:
             name: azure-storage-credentials
@@ -136,10 +142,12 @@ data:
           subPath: outputs
           readOnly: true
           recursiveReadOnly: IfPossible
+        {{ if .Values.local.storage -}}
         - name: local
           mountPath: /mnt/local
           readOnly: true
           recursiveReadOnly: IfPossible
+        {{ end -}}
         - name: orchestrator-storage
           mountPath: /mnt/orchestrator
         resources:
@@ -150,11 +158,13 @@ data:
       - name: storage
         persistentVolumeClaim:
           claimName: {{ `{{ id }}` }}
+      {{ if .Values.local.storage -}}
       - name: local
-        {{- with .Values.local.storage }}
-        {{- include "render" (dict "value" . "context" $) | nindent 8 }}
+        {{- with .Values.local.storage -}}
+        {{- include "render" (dict "value" . "context" $) | nindent 8 -}}
         {{- end }}
+      {{ end -}}
       - name: orchestrator-storage
-        {{- with .Values.orchestrator.storage }}
-        {{- include "render" (dict "value" . "context" $) | nindent 8 }}
+        {{- with .Values.orchestrator.storage -}}
+        {{- include "render" (dict "value" . "context" $) | nindent 8 -}}
         {{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,3 +1,5 @@
+{{- $storage := .Values.local.storage | required "The `local.storage` value is required." -}}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,7 +10,8 @@ data:
   # NOTE: all Tera template tags must be escaped for the Helm chart.
   task.yaml: |
     # This is the PVC used for the task's `disk` requirement.
-    # The task's inputs, outputs, work directory, and `/tmp` are all mounted from this volume.
+    # The task's non-local inputs, non-local outputs, work directory, and
+    # `/tmp` are all mounted from this volume.
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -44,7 +47,7 @@ data:
       # The first init container is responsible for downloading inputs and creating empty outputs to mount
       - name: inputs
         image: "{{ .Values.transporter.image.name }}:{{ .Values.transporter.image.tag | default .Chart.AppVersion }}"
-        args: ["-v", "--mode", "inputs", "--orchestrator-dir", "/mnt/orchestrator", "--inputs-dir", "/mnt/inputs", "--outputs-dir", "/mnt/outputs", {{ `{{ id | json_encode }}` }}]
+        args: ["-v", "--mode", "inputs", "--orchestrator-dir", "/mnt/orchestrator", "--inputs-dir", "/mnt/storage/inputs", "--outputs-dir", "/mnt/storage/outputs", "--local-dir", "/mnt/local", {{ `{{ id | json_encode }}` }}]
         envFrom:
         - secretRef:
             name: azure-storage-credentials
@@ -60,11 +63,9 @@ data:
           value: {{ .Values.transporter.log }}
         volumeMounts:
         - name: storage
-          mountPath: /mnt/inputs
-          subPath: inputs
-        - name: storage
-          mountPath: /mnt/outputs
-          subPath: outputs
+          mountPath: /mnt/storage
+        - name: local
+          mountPath: /mnt/local
         - name: orchestrator-storage
           mountPath: /mnt/orchestrator
           readOnly: true
@@ -93,29 +94,29 @@ data:
           - name: storage
             mountPath: /tmp
             subPath: tmp
-          {{ `{%- for input in inputs %}` }}
-          - name: storage
-            mountPath: {{ `{{ input }}` }}
-            subPath: inputs/{{ `{{ loop.index0 }}` }}
-            readOnly: true
-            recursiveReadOnly: IfPossible
-          {{ `{%- endfor -%}` }}
-          {{ `{%- for output in outputs %}` }}
-          - name: storage
-            mountPath: {{ `{{ output }}` }}
-            subPath: outputs/{{ `{{ loop.index0 }}` }}
-            {{ `{%- endfor -%}` }}
           {{ `{%- for volume in volumes %}` }}
           - name: storage
             mountPath: {{ `{{ volume }}` }}
             subPath: volumes/{{ `{{ loop.index0 }}` }}
           {{ `{%- endfor -%}` }}
+          {{ `{%- for input in inputs %}` }}
+          - name: {{ `{% if input.local_path %}local{% else %}storage{% endif %}` }}
+            mountPath: {{ `{{ input.path }}` }}
+            subPath: {{ `{% if input.local_path %}{{ input.local_path }}{% else %}inputs/{{loop.index0}}{% endif %}` }}
+            readOnly: true
+            recursiveReadOnly: IfPossible
+          {{ `{%- endfor -%}` }}
+          {{ `{%- for output in outputs %}` }}
+          - name: {{ `{% if output.local_path %}local{% else %}storage{% endif %}` }}
+            mountPath: {{ `{{ output.path }}` }}
+            subPath: {{ `{% if output.local_path %}{{ output.local_path }}{% else %}outputs/{{loop.index0}}{% endif %}` }}
+            {{ `{%- endfor -%}` }}
       {{ `{%- endfor %}` }}
       containers:
       # The primary container of the task pod is responsible for uploading the task's outputs
       - name: outputs
         image: "{{ .Values.transporter.image.name }}:{{ .Values.transporter.image.tag | default .Chart.AppVersion }}"
-        args: ["-v", "--mode", "outputs", "--orchestrator-dir", "/mnt/orchestrator", "--outputs-dir", "/mnt/outputs", {{ `{{ id | json_encode }}` }}]
+        args: ["-v", "--mode", "outputs", "--orchestrator-dir", "/mnt/orchestrator", "--outputs-dir", "/mnt/outputs", "--local-dir", "/mnt/local", {{ `{{ id | json_encode }}` }}]
         envFrom:
         - secretRef:
             name: azure-storage-credentials
@@ -135,6 +136,10 @@ data:
           subPath: outputs
           readOnly: true
           recursiveReadOnly: IfPossible
+        - name: local
+          mountPath: /mnt/local
+          readOnly: true
+          recursiveReadOnly: IfPossible
         - name: orchestrator-storage
           mountPath: /mnt/orchestrator
         resources:
@@ -145,6 +150,10 @@ data:
       - name: storage
         persistentVolumeClaim:
           claimName: {{ `{{ id }}` }}
+      - name: local
+        {{- with .Values.local.storage }}
+        {{- include "render" (dict "value" . "context" $) | nindent 8 }}
+        {{- end }}
       - name: orchestrator-storage
         {{- with .Values.orchestrator.storage }}
         {{- include "render" (dict "value" . "context" $) | nindent 8 }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -83,6 +83,8 @@ spec:
                 key: api-key
           - name: ALLOW_AUTHORIZATION_FALLBACK
             value: "{{ .Values.api.allowAuthorizationFallback }}"
+          - name: ALLOW_FILE_URLS
+            value: "{{ if .Values.local.storage }}true{{ else }}false{{ end }}"
 ---
 # Deployment for the Planetary orchestrator service
 apiVersion: apps/v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -204,5 +204,9 @@ networkPolicies:
       - port: 443
         protocol: TCP
 
+# The configuration for local (i.e. `file://` URLs) storage 
+local:
+  storage:
+
 # Extra Kubernetes resources to deploy along with Planetary
 extra: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -204,7 +204,7 @@ networkPolicies:
       - port: 443
         protocol: TCP
 
-# The configuration for local (i.e. `file://` URLs) storage 
+# The configuration for local (i.e., `file://` URLs) storage.
 local:
   storage:
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -205,8 +205,9 @@ networkPolicies:
         protocol: TCP
 
 # The configuration for local (i.e., `file://` URLs) storage.
+# By default, support for local storage will be disabled.
 local:
-  storage:
+  storage: null
 
 # Extra Kubernetes resources to deploy along with Planetary
 extra: []

--- a/db/CHANGELOG.md
+++ b/db/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added support retrieving usernames of tasks for template rendering ([#41](https://github.com/stjude-rust-labs/planetary/pull/41)).
 * Added `username` column to `tasks` table to associate tasks with TES API
   users ([#40](https://github.com/stjude-rust-labs/planetary/pull/40)).
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -96,6 +96,8 @@ pub struct TerminatedContainer<'a> {
 pub struct TaskTemplateData {
     /// The TES identifier of the task.
     pub id: String,
+    /// The user name associated with the task.
+    pub username: String,
     /// Whether or not the task is preemptible.
     pub preemptible: bool,
     /// The requested CPU cores for the task.

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -96,7 +96,7 @@ pub struct TerminatedContainer<'a> {
 pub struct TaskTemplateData {
     /// The TES identifier of the task.
     pub id: String,
-    /// The user name associated with the task.
+    /// The username associated with the task.
     pub username: String,
     /// Whether or not the task is preemptible.
     pub preemptible: bool,

--- a/db/src/postgres/models.rs
+++ b/db/src/postgres/models.rs
@@ -473,6 +473,8 @@ impl From<FullTask> for (ResponseTask, Vec<OutputFile>, Vec<String>) {
 pub struct TaskTemplateData {
     /// The task database identifier.
     pub id: i32,
+    /// The username associated with the task.
+    pub username: String,
     /// The TES identifier of the task.
     pub tes_id: String,
     /// The task inputs.
@@ -497,6 +499,7 @@ impl From<TaskTemplateData> for crate::TaskTemplateData {
     fn from(data: TaskTemplateData) -> Self {
         Self {
             id: data.tes_id,
+            username: data.username,
             preemptible: data.preemptible.unwrap_or(false),
             cpu: data.cpu_cores,
             memory: data.ram_gb,

--- a/orchestrator/src/orchestrator.rs
+++ b/orchestrator/src/orchestrator.rs
@@ -74,7 +74,7 @@ use crate::retry_durations;
 ///   orchestrator.
 /// * `outputs.json` - the task's outputs serialized as JSON; created by the
 ///   orchestrator.
-/// * `uploaded.json` - the task's uploaded outputs serialized as JSON; created
+/// * `files.json` - the task's actual output files serialized as JSON; created
 ///   by the transporter.
 ///
 /// A task's directory will be deleted when the task transitions to a terminal
@@ -130,9 +130,9 @@ fn outputs_file_path(tes_id: &str) -> PathBuf {
     task_directory_path(tes_id).join("outputs.json")
 }
 
-/// Gets the uploaded outputs file path for a TES task.
-fn uploaded_outputs_file_path(tes_id: &str) -> PathBuf {
-    task_directory_path(tes_id).join("uploaded.json")
+/// Gets the output files file path for a TES task.
+fn output_files_file_path(tes_id: &str) -> PathBuf {
+    task_directory_path(tes_id).join("files.json")
 }
 
 /// Helper function for serializing an array of serializable items to a file.
@@ -823,7 +823,7 @@ impl TaskOrchestrator {
 
     /// Handles a succeeded task.
     async fn handle_succeeded_task(&self, tes_id: &str, pod: &Pod) -> Result<(), Error> {
-        let outputs = deserialize_items(uploaded_outputs_file_path(tes_id))?;
+        let outputs = deserialize_items(output_files_file_path(tes_id))?;
 
         if self
             .database
@@ -849,7 +849,7 @@ impl TaskOrchestrator {
         index: usize,
         pod: &Pod,
     ) -> Result<(), Error> {
-        let outputs = deserialize_items(uploaded_outputs_file_path(tes_id))?;
+        let outputs = deserialize_items(output_files_file_path(tes_id))?;
 
         if self
             .database
@@ -872,7 +872,7 @@ impl TaskOrchestrator {
 
     /// Handles a system error.
     async fn handle_system_error(&self, tes_id: &str, pod: &Pod) -> Result<(), Error> {
-        let outputs = deserialize_items(uploaded_outputs_file_path(tes_id))?;
+        let outputs = deserialize_items(output_files_file_path(tes_id))?;
 
         if self
             .database
@@ -895,7 +895,7 @@ impl TaskOrchestrator {
 
     /// Handles a pod in an unknown state.
     async fn handle_unknown_pod(&self, tes_id: &str, pod: &Pod) -> Result<(), Error> {
-        let outputs = deserialize_items(uploaded_outputs_file_path(tes_id))?;
+        let outputs = deserialize_items(output_files_file_path(tes_id))?;
 
         if self
             .database

--- a/orchestrator/src/orchestrator.rs
+++ b/orchestrator/src/orchestrator.rs
@@ -74,7 +74,7 @@ use crate::retry_durations;
 ///   orchestrator.
 /// * `outputs.json` - the task's outputs serialized as JSON; created by the
 ///   orchestrator.
-/// * `files.json` - the task's actual output files serialized as JSON; created
+/// * `final.json` - the task's final output files serialized as JSON; created
 ///   by the transporter.
 ///
 /// A task's directory will be deleted when the task transitions to a terminal
@@ -130,9 +130,9 @@ fn outputs_file_path(tes_id: &str) -> PathBuf {
     task_directory_path(tes_id).join("outputs.json")
 }
 
-/// Gets the output files file path for a TES task.
+/// Gets the final outputs file path for a TES task.
 fn output_files_file_path(tes_id: &str) -> PathBuf {
-    task_directory_path(tes_id).join("files.json")
+    task_directory_path(tes_id).join("final.json")
 }
 
 /// Helper function for serializing an array of serializable items to a file.

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Added support for rendering templates with local inputs and outputs ([#41](https://github.com/stjude-rust-labs/planetary/pull/41)).
+
 #### Dependencies
 
 * Updated dependencies to latest ([#37](https://github.com/stjude-rust-labs/planetary/pull/37)).

--- a/server/src/templating.rs
+++ b/server/src/templating.rs
@@ -24,6 +24,28 @@ use tera::Tera;
 use tera::Value;
 use tes::v1::types::task::Executor;
 
+/// Helper for stripping the `file:///` prefix from a file-schemed URL.
+///
+/// Ignores casing for the URL's scheme.
+///
+/// Returns `None` if the URL is not for the `file` scheme or if the URL is not
+/// absolute.
+fn url_to_relative_path(url: &str) -> Option<&str> {
+    const PREFIX: &str = "file:///";
+
+    let url = url.trim_start();
+
+    if url.len() < PREFIX.len() {
+        return None;
+    }
+
+    if !url[0..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
+        return None;
+    }
+
+    Some(&url[PREFIX.len()..])
+}
+
 /// The orchestrator id label.
 pub const ORCHESTRATOR_LABEL: &str = "planetary/orchestrator";
 
@@ -153,6 +175,7 @@ impl Template {
         self.render(
             &TaskTemplateData {
                 id: id.into(),
+                username: String::new(),
                 preemptible: false,
                 cpu: None,
                 memory: None,
@@ -189,6 +212,7 @@ impl Template {
 
         let mut context = Map::new();
         insert(&mut context, "id", data.id.as_str());
+        insert(&mut context, "username", data.username.as_str());
         insert(&mut context, "preemptible", data.preemptible);
 
         // Set the requested resources
@@ -211,11 +235,39 @@ impl Template {
         );
 
         // Set the inputs
-        let inputs: Vec<Value> = data.inputs.iter().map(|i| i.path.clone().into()).collect();
+        let inputs: Vec<Value> = data
+            .inputs
+            .iter()
+            .map(|input| {
+                let mut value = Map::new();
+                value.insert("path".to_string(), input.path.clone().into());
+
+                if let Some(local_path) =
+                    input.url.as_ref().and_then(|url| url_to_relative_path(url))
+                {
+                    value.insert("local_path".to_string(), local_path.to_string().into());
+                }
+
+                value.into()
+            })
+            .collect();
         insert(&mut context, "inputs", inputs);
 
         // Set the outputs
-        let outputs: Vec<Value> = data.outputs.iter().map(|o| o.path.clone().into()).collect();
+        let outputs: Vec<Value> = data
+            .outputs
+            .iter()
+            .map(|output| {
+                let mut value = Map::new();
+                value.insert("path".to_string(), output.path.clone().into());
+
+                if let Some(local_path) = url_to_relative_path(&output.url) {
+                    value.insert("local_path".to_string(), local_path.to_string().into());
+                }
+
+                value.into()
+            })
+            .collect();
         insert(&mut context, "outputs", outputs);
 
         // Set the volumes

--- a/server/src/templating.rs
+++ b/server/src/templating.rs
@@ -237,10 +237,12 @@ impl Template {
 
                 if let Some(local_path) = input.url.as_ref().and_then(|url| {
                     Some(
+                        // SAFETY: URLs are validated when tasks are created
                         url_to_file_path(url)?
                             .strip_prefix("/")
                             .expect("path should be absolute")
-                            .to_str()?
+                            .to_str()
+                            .expect("path should be UTF-8")
                             .to_string(),
                     )
                 }) {
@@ -260,12 +262,13 @@ impl Template {
                 let mut value = Map::new();
                 value.insert("path".to_string(), output.path.clone().into());
 
-                if let Some(path) = url_to_file_path(&output.url)
-                    && let Some(local_path) = path
+                if let Some(path) = url_to_file_path(&output.url) {
+                    // SAFETY: URLs are validated when tasks are created
+                    let local_path = path
                         .strip_prefix("/")
                         .expect("path should be absolute")
                         .to_str()
-                {
+                        .expect("path should be UTF-8");
                     value.insert("local_path".to_string(), local_path.into());
                 }
 

--- a/server/src/templating.rs
+++ b/server/src/templating.rs
@@ -4,6 +4,7 @@
 //! the monitor when tasks are garbage collected.
 
 use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::Context as _;
 use anyhow::Result;
@@ -16,6 +17,7 @@ use kube::discovery::ApiCapabilities;
 use kube::discovery::Scope;
 use kube::runtime::reflector::Lookup;
 use planetary_db::TaskTemplateData;
+use reqwest::Url;
 use serde::Deserialize as _;
 use serde_yaml_ng::Deserializer;
 use tera::Context;
@@ -23,28 +25,6 @@ use tera::Map;
 use tera::Tera;
 use tera::Value;
 use tes::v1::types::task::Executor;
-
-/// Helper for stripping the `file:///` prefix from a file-schemed URL.
-///
-/// Ignores casing for the URL's scheme.
-///
-/// Returns `None` if the URL is not for the `file` scheme or if the URL is not
-/// absolute.
-fn url_to_relative_path(url: &str) -> Option<&str> {
-    const PREFIX: &str = "file:///";
-
-    let url = url.trim_start();
-
-    if url.len() < PREFIX.len() {
-        return None;
-    }
-
-    if !url[0..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
-        return None;
-    }
-
-    Some(&url[PREFIX.len()..])
-}
 
 /// The orchestrator id label.
 pub const ORCHESTRATOR_LABEL: &str = "planetary/orchestrator";
@@ -70,6 +50,19 @@ const DEFAULT_CPU: i32 = 1;
 ///
 /// Uses a 256 MiB default.
 const DEFAULT_MEMORY: f64 = 0.268435455;
+
+/// Helper for converting a URL to a file path.
+///
+/// Returns `None` if the URL is invalid or if the URL does not represent a file
+/// path.
+fn url_to_file_path(url: &str) -> Option<PathBuf> {
+    let url = Url::parse(url).ok()?;
+    if url.scheme() != "file" {
+        return None;
+    }
+
+    url.to_file_path().ok()
+}
 
 /// Represents a Planetary task template.
 ///
@@ -242,10 +235,16 @@ impl Template {
                 let mut value = Map::new();
                 value.insert("path".to_string(), input.path.clone().into());
 
-                if let Some(local_path) =
-                    input.url.as_ref().and_then(|url| url_to_relative_path(url))
-                {
-                    value.insert("local_path".to_string(), local_path.to_string().into());
+                if let Some(local_path) = input.url.as_ref().and_then(|url| {
+                    Some(
+                        url_to_file_path(url)?
+                            .strip_prefix("/")
+                            .expect("path should be absolute")
+                            .to_str()?
+                            .to_string(),
+                    )
+                }) {
+                    value.insert("local_path".to_string(), local_path.into());
                 }
 
                 value.into()
@@ -261,8 +260,13 @@ impl Template {
                 let mut value = Map::new();
                 value.insert("path".to_string(), output.path.clone().into());
 
-                if let Some(local_path) = url_to_relative_path(&output.url) {
-                    value.insert("local_path".to_string(), local_path.to_string().into());
+                if let Some(path) = url_to_file_path(&output.url)
+                    && let Some(local_path) = path
+                        .strip_prefix("/")
+                        .expect("path should be absolute")
+                        .to_str()
+                {
+                    value.insert("local_path".to_string(), local_path.into());
                 }
 
                 value.into()

--- a/transporter/CHANGELOG.md
+++ b/transporter/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added support for local (file://) inputs and outputs ([#41](https://github.com/stjude-rust-labs/planetary/pull/41)).
 * Added `--azure-account-name` and `--azure-access-key` options for Azure
   Storage authentication ([#27](https://github.com/stjude-rust-labs/planetary/pull/27)).
 

--- a/transporter/Cargo.toml
+++ b/transporter/Cargo.toml
@@ -40,3 +40,10 @@ walkdir.workspace = true
 
 [lints]
 workspace = true
+
+[features]
+default = []
+# This feature exists so that every crate in the workspace has the same feature set.
+# Currently `rust-analyzer` doesn't support per-crate feature flags for its check,
+# so this is needed to analyze the entire workspace with the `postgres` feature enabled.
+postgres = []

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -17,8 +17,8 @@
 //!
 //! For the `outputs` mode, the transporter only reads from `outputs.json` and
 //! uploads the outputs to the expected cloud storage location. The transporter
-//! will then create an `uploaded.json` file in orchestrator shared storage to
-//! record what was uploaded by the transporter. The orchestrator uses that
+//! will then create a `files.json` file in orchestrator shared storage to
+//! record the files the TES task actually output. The orchestrator uses that
 //! information to record output files for the TES task.
 //!
 //! The entries of the target directory will be created or accessed based on
@@ -50,9 +50,6 @@ use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -72,6 +69,7 @@ use cloud_copy::S3Config;
 use cloud_copy::TransferEvent;
 use cloud_copy::UrlExt;
 use cloud_copy::cli::TimeDeltaExt;
+use cloud_copy::cli::TransferStats;
 use cloud_copy::cli::handle_events;
 use futures::FutureExt;
 use futures::StreamExt;
@@ -103,30 +101,23 @@ use walkdir::WalkDir;
 /// lagged.
 const EVENTS_CAPACITY: usize = 1000;
 
-/// Helper for stripping the `file:///` prefix from a file-schemed URL.
+/// Helper for converting a URL to a file path.
 ///
-/// Ignores casing for the URL's scheme.
+/// The returned path is guaranteed to be absolute.
 ///
-/// Returns `None` if the URL is not for the `file` scheme or if the URL is not
-/// absolute.
-fn url_to_relative_path(url: &str) -> Option<&str> {
-    const PREFIX: &str = "file:///";
-
-    let url = url.trim_start();
-
-    if url.len() < PREFIX.len() {
+/// Returns `None` if the URL is invalid or if the URL does not represent a file
+/// path.
+fn url_to_file_path(url: &str) -> Option<PathBuf> {
+    let url: Url = Url::parse(url).ok()?;
+    if url.scheme() != "file" {
         return None;
     }
 
-    if !url[0..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
-        return None;
-    }
-
-    Some(&url[PREFIX.len()..])
+    url.to_file_path().ok()
 }
 
 /// Prints the statistics after transferring inputs or outputs.
-fn print_stats(delta: TimeDelta, files: usize, bytes: u64) {
+fn print_stats(delta: TimeDelta, TransferStats { files, bytes }: TransferStats) {
     let seconds = delta.num_seconds();
 
     println!(
@@ -186,9 +177,11 @@ struct Args {
     #[arg(long)]
     outputs_dir: PathBuf,
 
-    /// The path to the "local" directory for `file://` inputs and outputs.
+    /// The optional path to the "local" directory for `file://` inputs and outputs.
+    ///
+    /// `file://` inputs and outputs will be disabled if not specified.
     #[arg(long)]
-    local_dir: PathBuf,
+    local_dir: Option<PathBuf>,
 
     /// The verbosity level.
     #[command(flatten)]
@@ -268,9 +261,9 @@ fn outputs_file_path(orchestrator_dir: &Path, tes_id: &str) -> PathBuf {
     orchestrator_dir.join(tes_id).join("outputs.json")
 }
 
-/// Gets the uploaded outputs file path for a TES task.
-fn uploaded_outputs_file_path(orchestrator_dir: &Path, tes_id: &str) -> PathBuf {
-    orchestrator_dir.join(tes_id).join("uploaded.json")
+/// Gets the final outputs file path for a TES task.
+fn output_files_file_path(orchestrator_dir: &Path, tes_id: &str) -> PathBuf {
+    orchestrator_dir.join(tes_id).join("final.json")
 }
 
 /// Helper function for serializing an array of serializable items to a file.
@@ -307,66 +300,42 @@ fn deserialize_items<T: DeserializeOwned>(path: impl AsRef<Path>) -> anyhow::Res
         .with_context(|| format!("failed to read file `{path}`", path = path.display()))
 }
 
-/// Represents context for transferring inputs.
+/// Represents context for file transfers.
 #[derive(Clone)]
-struct InputTransferContext {
+struct TransferContext {
     /// The cloud copy configuration to use for copy operations.
     config: Config,
     /// The HTTP client to use for copy operations.
     client: HttpClient,
-    /// The count of files created by the transporter.
-    ///
-    /// This is for inputs with specified contents that are not being
-    /// downloaded.
-    created: Arc<AtomicUsize>,
     /// The cancellation token to use for cancelling input downloads.
     cancel: CancellationToken,
     /// The transfer events channel.
     events: broadcast::Sender<TransferEvent>,
 }
 
-impl InputTransferContext {
+impl TransferContext {
     /// Constructs a new input transfer context from the given cloud copy
     /// configuration and cancellation token.
     fn new(config: Config, cancel: CancellationToken) -> Self {
         Self {
             config,
             client: HttpClient::new(),
-            created: Arc::default(),
             cancel,
             events: broadcast::channel(EVENTS_CAPACITY).0,
         }
     }
 }
 
-/// Represents context for transferring outputs.
-#[derive(Clone)]
-struct OutputTransferContext {
-    /// The cloud copy configuration to use for copy operations.
-    config: Config,
-    /// The HTTP client to use for copy operations.
-    client: HttpClient,
-    /// The cancellation token to use for cancelling input downloads.
-    cancel: CancellationToken,
-    /// The transfer events channel.
-    events: broadcast::Sender<TransferEvent>,
-}
-
-impl OutputTransferContext {
-    /// Constructs a new output transfer context from the given cloud copy
-    /// configuration and cancellation token.
-    fn new(config: Config, cancel: CancellationToken) -> Self {
-        Self {
-            config,
-            client: HttpClient::new(),
-            cancel,
-            events: broadcast::channel(EVENTS_CAPACITY).0,
-        }
-    }
-}
-
-/// Downloads an individual input to the specified path.
-async fn download_input(context: InputTransferContext, input: &Input, path: &Path) -> Result<()> {
+/// Prepares an individual input at the specified path.
+///
+/// For inputs with specified contents, a new file will be created at the
+/// specified path with the requested content.
+///
+/// For remote inputs, this will download the file to the specified path.
+///
+/// For local inputs, this will ensure that the specified path exists and is the
+/// expected type.
+async fn prepare_input(context: TransferContext, input: &Input, path: &Path) -> Result<()> {
     let permissions = if let Some(contents) = &input.content {
         // Write the contents if directly given, but only if the input is a file
         match input.ty {
@@ -386,7 +355,6 @@ async fn download_input(context: InputTransferContext, input: &Input, path: &Pat
             .await
             .with_context(|| format!("failed to create input file `{path}`", path = input.path))?;
 
-        context.created.fetch_add(1, Ordering::SeqCst);
         0o444
     } else {
         let url = input
@@ -482,18 +450,21 @@ async fn download_input(context: InputTransferContext, input: &Input, path: &Pat
     Ok(())
 }
 
-/// Downloads inputs into the inputs directory.
+/// Prepares task inputs.
+///
+/// Remote inputs are copied locally and local inputs are checked for existence.
 ///
 /// This will also create empty files and directories for outputs in the outputs
-/// directory.
-async fn download_inputs(
-    context: InputTransferContext,
+/// directory; this is required because Kubernetes will create directory mounts
+/// if the file doesn't exist.
+async fn prepare_inputs(
+    context: TransferContext,
     tes_id: &str,
     orchestrator_dir: &Path,
     inputs_dir: &Path,
     outputs_dir: &Path,
-    local_dir: &Path,
-) -> Result<()> {
+    local_dir: Option<&Path>,
+) -> Result<(TimeDelta, Option<TransferStats>)> {
     let inputs: Vec<Input> = deserialize_items(inputs_file_path(orchestrator_dir, tes_id))?;
     let outputs: Vec<Output> = deserialize_items(outputs_file_path(orchestrator_dir, tes_id))?;
 
@@ -518,25 +489,38 @@ async fn download_inputs(
     let cancel = context.cancel.clone();
     let handler = tokio::spawn(async move { handle_events(events, false, cancel).await });
 
-    // Create a transfer task for downloading each input
+    // Create a task for preparing each input
     let ctx = context.clone();
-    let transfer = async move || {
-        let mut downloads = stream::iter(inputs.into_iter().enumerate())
+    let prepare = async move || {
+        let mut tasks = stream::iter(inputs.into_iter().enumerate())
             .map(|(index, input)| {
-                let path =
-                    if let Some(sub_path) = input.url.as_deref().and_then(url_to_relative_path) {
-                        local_dir.join(sub_path)
+                let inputs_dir = inputs_dir.to_path_buf();
+                let local_dir = local_dir.map(Path::to_path_buf);
+                let ctx = ctx.clone();
+                tokio::spawn(async move {
+                    let path = if let Some(url) = input.url.as_deref()
+                        && let Some(path) = url_to_file_path(url)
+                    {
+                        match local_dir {
+                            Some(local_dir) => {
+                                local_dir.join(path.strip_prefix("/").with_context(|| {
+                                    format!("input URL `{url}` is not absolute")
+                                })?)
+                            }
+                            None => bail!("input file URL `{url}` is not supported"),
+                        }
                     } else {
                         inputs_dir.join(index.to_string())
                     };
-                let ctx = ctx.clone();
-                tokio::spawn(async move { download_input(ctx, &input, &path).await })
-                    .map(|r| r.expect("task panicked"))
+
+                    prepare_input(ctx, &input, &path).await
+                })
+                .map(|r| r.expect("task panicked"))
             })
             .buffer_unordered(context.config.parallelism());
 
         loop {
-            let result = downloads.next().await;
+            let result = tasks.next().await;
             match result {
                 Some(r) => r?,
                 None => break,
@@ -546,25 +530,13 @@ async fn download_inputs(
         anyhow::Ok(())
     };
 
-    // Perform the transfer
+    // Prepare (and potentially download) the inputs
     let start = Utc::now();
-    let result = transfer().await;
+    let result = prepare().await;
     let end = Utc::now();
 
     drop(context.events);
     let stats = handler.await.expect("failed to join events handler");
-
-    // Print the statistics upon success
-    if result.is_ok()
-        && let Some(stats) = stats
-    {
-        print_stats(
-            end - start,
-            context.created.load(Ordering::SeqCst) + stats.files,
-            stats.bytes,
-        );
-    }
-
     result?;
 
     // We also need to create any file outputs so that Kubernetes will mount them as
@@ -572,8 +544,13 @@ async fn download_inputs(
     for (index, output) in outputs.into_iter().enumerate() {
         // For local `file://` output URLs, create the file or directory at the
         // expected output location; executor containers will mount it directly.
-        if let Some(path) = url_to_relative_path(&output.url) {
-            let path = local_dir.join(path);
+        if let Some(path) = url_to_file_path(&output.url) {
+            let path = match local_dir {
+                Some(local_dir) => local_dir.join(path.strip_prefix("/").with_context(|| {
+                    format!("output URL `{url}` is not absolute", url = output.url)
+                })?),
+                None => bail!("output file URL `{url}` is not supported", url = output.url),
+            };
 
             // Create the parent directory for the output
             if let Some(parent) = path.parent() {
@@ -629,12 +606,21 @@ async fn download_inputs(
             })?;
     }
 
-    Ok(())
+    Ok((end - start, stats))
 }
 
-/// Uploads an output at the given path to the requested location.
-async fn upload_output(
-    context: OutputTransferContext,
+/// Prepares an output.
+///
+/// For remote outputs, the output is uploaded to the requested location.
+///
+/// For local outputs, the output is not uploaded.
+///
+/// If the output is a directory it is recursively scanned for files.
+///
+/// Returns the set of discovered output files that will be used for associating
+/// a TES task with its actual output files.
+async fn prepare_output(
+    context: TransferContext,
     output: &Output,
     path: &Path,
 ) -> Result<Vec<OutputFile>> {
@@ -648,7 +634,7 @@ async fn upload_output(
     })?;
 
     if metadata.is_dir() {
-        return upload_directory(context, output, &url, path).await;
+        return prepare_directory_output(context, output, &url, path).await;
     }
 
     if output.ty != IoType::File {
@@ -695,75 +681,16 @@ async fn upload_output(
     }])
 }
 
-/// Uploads outputs from the specified outputs directory.
-async fn upload_outputs(
-    context: OutputTransferContext,
-    tes_id: &str,
-    orchestrator_dir: &Path,
-    outputs_dir: &Path,
-    local_dir: &Path,
-) -> Result<()> {
-    let outputs: Vec<Output> = deserialize_items(outputs_file_path(orchestrator_dir, tes_id))?;
-
-    // Create an event handling task
-    let events = context.events.subscribe();
-    let cancel = context.cancel.clone();
-    let handler = tokio::spawn(async move { handle_events(events, false, cancel).await });
-
-    // Transfer the outputs
-    let transfer = async || {
-        let mut files = Vec::new();
-        let mut uploads = stream::iter(outputs.into_iter().enumerate())
-            .map(|(index, output)| {
-                let path = if let Some(sub_path) = output.url.strip_prefix("file:///") {
-                    local_dir.join(sub_path)
-                } else {
-                    outputs_dir.join(index.to_string())
-                };
-                let ctx = context.clone();
-                tokio::spawn(async move { upload_output(ctx, &output, &path).await })
-                    .map(|r| r.expect("task panicked"))
-            })
-            .buffer_unordered(context.config.parallelism());
-
-        loop {
-            let result = uploads.next().await;
-            match result {
-                Some(r) => files.extend(r?),
-                None => break,
-            }
-        }
-
-        anyhow::Ok(files)
-    };
-
-    // Perform the transfer
-    let start = Utc::now();
-    let result = transfer().await;
-    let end = Utc::now();
-
-    drop(context.events);
-    let stats = handler.await.expect("failed to join events handler");
-
-    let outputs = result?;
-
-    // Write the uploads file
-    serialize_items(
-        uploaded_outputs_file_path(orchestrator_dir, tes_id),
-        &outputs,
-    )?;
-
-    // Print the statistics
-    if let Some(stats) = stats {
-        print_stats(end - start, stats.files, stats.bytes);
-    }
-
-    Ok(())
-}
-
-/// Uploads a directory output.
-async fn upload_directory(
-    context: OutputTransferContext,
+/// Prepares a directory output.
+///
+/// This will recursively search the directory for files.
+///
+/// If the URL of the output is remote, each file is uploaded to cloud storage
+/// at the corresponding relative path.
+///
+/// Returns the output files discovered during the walk of the directory.
+async fn prepare_directory_output(
+    context: TransferContext,
     output: &Output,
     url: &Url,
     directory: &Path,
@@ -872,6 +799,82 @@ async fn upload_directory(
     Ok(files)
 }
 
+/// Prepares outputs from the specified outputs and local directory.
+///
+/// Each remote output is uploaded to cloud storage.
+///
+/// Responsible for writing the `outputs.json`
+async fn prepare_outputs(
+    context: TransferContext,
+    tes_id: &str,
+    orchestrator_dir: &Path,
+    outputs_dir: &Path,
+    local_dir: Option<&Path>,
+) -> Result<(TimeDelta, Option<TransferStats>)> {
+    let outputs: Vec<Output> = deserialize_items(outputs_file_path(orchestrator_dir, tes_id))?;
+
+    // Create an event handling task
+    let events = context.events.subscribe();
+    let cancel = context.cancel.clone();
+    let handler = tokio::spawn(async move { handle_events(events, false, cancel).await });
+
+    // Create a task for preparing each output
+    let prepare = async || {
+        let mut files = Vec::new();
+        let mut tasks = stream::iter(outputs.into_iter().enumerate())
+            .map(|(index, output)| {
+                let outputs_dir = outputs_dir.to_path_buf();
+                let local_dir = local_dir.map(Path::to_path_buf);
+                let ctx = context.clone();
+                tokio::spawn(async move {
+                    let path = if let Some(path) = url_to_file_path(&output.url) {
+                        match local_dir {
+                            Some(local_dir) => {
+                                local_dir.join(path.strip_prefix("/").with_context(|| {
+                                    format!("output URL `{url}` is not absolute", url = output.url)
+                                })?)
+                            }
+                            None => {
+                                bail!("output file URL `{url}` is not supported", url = output.url)
+                            }
+                        }
+                    } else {
+                        outputs_dir.join(index.to_string())
+                    };
+
+                    prepare_output(ctx, &output, &path).await
+                })
+                .map(|r| r.expect("task panicked"))
+            })
+            .buffer_unordered(context.config.parallelism());
+
+        loop {
+            let result = tasks.next().await;
+            match result {
+                Some(r) => files.extend(r?),
+                None => break,
+            }
+        }
+
+        anyhow::Ok(files)
+    };
+
+    // Prepare (and potentially upload) the outputs
+    let start = Utc::now();
+    let result = prepare().await;
+    let end = Utc::now();
+
+    drop(context.events);
+    let stats = handler.await.expect("failed to join events handler");
+
+    let outputs = result?;
+
+    // Write the output files for the task
+    serialize_items(output_files_file_path(orchestrator_dir, tes_id), &outputs)?;
+
+    Ok((end - start, stats))
+}
+
 #[cfg(unix)]
 /// An async function that waits for a termination signal.
 async fn terminate(cancel: CancellationToken) {
@@ -965,31 +968,38 @@ async fn run(cancel: CancellationToken) -> Result<()> {
         .with_google(google)
         .build();
 
-    match args.mode {
+    let context = TransferContext::new(config, cancel);
+
+    let (delta, stats) = match args.mode {
         Mode::Inputs => {
-            let context = InputTransferContext::new(config, cancel);
-            download_inputs(
+            prepare_inputs(
                 context,
                 &args.tes_id,
                 &args.orchestrator_dir,
                 &args.inputs_dir.expect("option should be present"),
                 &args.outputs_dir,
-                &args.local_dir,
+                args.local_dir.as_deref(),
             )
-            .await
+            .await?
         }
         Mode::Outputs => {
-            let context = OutputTransferContext::new(config, cancel);
-            upload_outputs(
+            prepare_outputs(
                 context,
                 &args.tes_id,
                 &args.orchestrator_dir,
                 &args.outputs_dir,
-                &args.local_dir,
+                args.local_dir.as_deref(),
             )
-            .await
+            .await?
         }
+    };
+
+    // Print the statistics if there are some
+    if let Some(stats) = stats {
+        print_stats(delta, stats);
     }
+
+    Ok(())
 }
 
 #[tokio::main]

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -17,8 +17,8 @@
 //!
 //! For the `outputs` mode, the transporter only reads from `outputs.json` and
 //! uploads the outputs to the expected cloud storage location. The transporter
-//! will then create a `files.json` file in orchestrator shared storage to
-//! record the files the TES task actually output. The orchestrator uses that
+//! will then create a `final.json` file in orchestrator shared storage to
+//! record the final output files of the TES task. The orchestrator uses that
 //! information to record output files for the TES task.
 //!
 //! The entries of the target directory will be created or accessed based on
@@ -800,7 +800,7 @@ async fn prepare_directory_output(
 ///
 /// Each remote output is uploaded to cloud storage.
 ///
-/// Responsible for creating the `files.json` file for the task that is read by
+/// Responsible for creating the `final.json` file for the task that is read by
 /// the orchestrator.
 async fn prepare_outputs(
     context: TransferContext,

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -28,7 +28,7 @@
 //! will create entries such as `/mnt/inputs/0`, `/mnt/inputs/1`, etc.
 //!
 //! Likewise, with the `--outputs-dir /mnt/outputs` option, the transporter will
-//! create (for `inputs`` mode) or access (for `outputs` mode) entries such as
+//! create (for `inputs` mode) or access (for `outputs` mode) entries such as
 //! `/mnt/outputs/0`, `/mnt/outputs/1`, etc.
 //!
 //! For "local" inputs (those with `file://` URLs), the transporter will verify

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -1,27 +1,43 @@
 //! Responsible for "transporting" a Planetary task's inputs and outputs.
 //!
-//! This tool is built into a container image that is used by Planetary.
+//! This tool is built into a container image that is used internally by
+//! Planetary.
 //!
-//! The executable requires either the `--inputs` or `--outputs` option.
+//! The executable requires either the `--mode inputs` or `--mode outputs`
+//! option.
 //!
-//! If the `--inputs` option is specified, the argument is expected to be a path
-//! to a JSON file containing an array of TES inputs.
+//! For the `inputs` mode, the transporter reads the `inputs.json` file from
+//! orchestrator shared storage for the task. The inputs are then downloaded as
+//! required to the expected location for mounting the inputs into executor
+//! containers.
 //!
-//! If the `--outputs` option is specified, the argument is expected to be a
-//! path to a JSON file containing an array of TES outputs.
+//! Additionally, the transporter also reads the `outputs.json` file from
+//! orchestrator shared storage so that it can create a file or directory at the
+//! expected location for mounting the outputs into the executor containers.
 //!
-//! The `--target` argument is the directory where either inputs are created or
-//! the outputs are sourced from.
+//! For the `outputs` mode, the transporter only reads from `outputs.json` and
+//! uploads the outputs to the expected cloud storage location. The transporter
+//! will then create an `uploaded.json` file in orchestrator shared storage to
+//! record what was uploaded by the transporter. The orchestrator uses that
+//! information to record output files for the TES task.
 //!
 //! The entries of the target directory will be created or accessed based on
 //! their index within the array of inputs or outputs.
 //!
-//! For example, if the `--inputs` option is used with `--targets /mnt/inputs`,
-//! this program will create entries such as `/mnt/inputs/0`, `/mnt/inputs/1`,
-//! etc.
+//! For example, with the `--inputs-dir /mnt/inputs` option, the transporter
+//! will create entries such as `/mnt/inputs/0`, `/mnt/inputs/1`, etc.
 //!
-//! Likewise, if the `--outputs` option is used with `--targets /mnt/outputs`,
-//! it will access `/mnt/outputs/0`, `/mnt/outputs/1`, etc.
+//! Likewise, with the `--outputs-dir /mnt/outputs` option, the transporter will
+//! create (for `inputs`` mode) or access (for `outputs` mode) entries such as
+//! `/mnt/outputs/0`, `/mnt/outputs/1`, etc.
+//!
+//! For "local" inputs (those with `file://` URLs), the transporter will verify
+//! that the inputs exist. Local input files aren't copied; instead they are
+//! mounted directly from the local volume.
+//!
+//! For "local" outputs (those with `file://` URLs), the transporter will
+//! recursively search for files for recording outputs of the TES task. Local
+//! output files aren't copied.
 
 use std::fs;
 use std::fs::Permissions;
@@ -83,6 +99,32 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use walkdir::WalkDir;
 
+/// The number of transfer events to buffer before the event handler becomes
+/// lagged.
+const EVENTS_CAPACITY: usize = 1000;
+
+/// Helper for stripping the `file:///` prefix from a file-schemed URL.
+///
+/// Ignores casing for the URL's scheme.
+///
+/// Returns `None` if the URL is not for the `file` scheme or if the URL is not
+/// absolute.
+fn url_to_relative_path(url: &str) -> Option<&str> {
+    const PREFIX: &str = "file:///";
+
+    let url = url.trim_start();
+
+    if url.len() < PREFIX.len() {
+        return None;
+    }
+
+    if !url[0..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
+        return None;
+    }
+
+    Some(&url[PREFIX.len()..])
+}
+
 /// Prints the statistics after transferring inputs or outputs.
 fn print_stats(delta: TimeDelta, files: usize, bytes: u64) {
     let seconds = delta.num_seconds();
@@ -143,6 +185,10 @@ struct Args {
     /// The path to the task's outputs directory.
     #[arg(long)]
     outputs_dir: PathBuf,
+
+    /// The path to the "local" directory for `file://` inputs and outputs.
+    #[arg(long)]
+    local_dir: PathBuf,
 
     /// The verbosity level.
     #[command(flatten)]
@@ -261,17 +307,192 @@ fn deserialize_items<T: DeserializeOwned>(path: impl AsRef<Path>) -> anyhow::Res
         .with_context(|| format!("failed to read file `{path}`", path = path.display()))
 }
 
+/// Represents context for transferring inputs.
+#[derive(Clone)]
+struct InputTransferContext {
+    /// The cloud copy configuration to use for copy operations.
+    config: Config,
+    /// The HTTP client to use for copy operations.
+    client: HttpClient,
+    /// The count of files created by the transporter.
+    ///
+    /// This is for inputs with specified contents that are not being
+    /// downloaded.
+    created: Arc<AtomicUsize>,
+    /// The cancellation token to use for cancelling input downloads.
+    cancel: CancellationToken,
+    /// The transfer events channel.
+    events: broadcast::Sender<TransferEvent>,
+}
+
+impl InputTransferContext {
+    /// Constructs a new input transfer context from the given cloud copy
+    /// configuration and cancellation token.
+    fn new(config: Config, cancel: CancellationToken) -> Self {
+        Self {
+            config,
+            client: HttpClient::new(),
+            created: Arc::default(),
+            cancel,
+            events: broadcast::channel(EVENTS_CAPACITY).0,
+        }
+    }
+}
+
+/// Represents context for transferring outputs.
+#[derive(Clone)]
+struct OutputTransferContext {
+    /// The cloud copy configuration to use for copy operations.
+    config: Config,
+    /// The HTTP client to use for copy operations.
+    client: HttpClient,
+    /// The cancellation token to use for cancelling input downloads.
+    cancel: CancellationToken,
+    /// The transfer events channel.
+    events: broadcast::Sender<TransferEvent>,
+}
+
+impl OutputTransferContext {
+    /// Constructs a new output transfer context from the given cloud copy
+    /// configuration and cancellation token.
+    fn new(config: Config, cancel: CancellationToken) -> Self {
+        Self {
+            config,
+            client: HttpClient::new(),
+            cancel,
+            events: broadcast::channel(EVENTS_CAPACITY).0,
+        }
+    }
+}
+
+/// Downloads an individual input to the specified path.
+async fn download_input(context: InputTransferContext, input: &Input, path: &Path) -> Result<()> {
+    let permissions = if let Some(contents) = &input.content {
+        // Write the contents if directly given, but only if the input is a file
+        match input.ty {
+            IoType::File => {}
+            IoType::Directory => bail!(
+                "cannot create content for directory input `{path}`",
+                path = input.path
+            ),
+        }
+
+        info!(
+            "creating input file `{path}` with specified contents",
+            path = input.path,
+        );
+
+        tokio::fs::write(&path, contents)
+            .await
+            .with_context(|| format!("failed to create input file `{path}`", path = input.path))?;
+
+        context.created.fetch_add(1, Ordering::SeqCst);
+        0o444
+    } else {
+        let url = input
+            .url
+            .as_ref()
+            .context("input is missing a URL")?
+            .parse::<Url>()
+            .context("input URL is invalid")?;
+
+        // For `file://` URLs, just ensure the path exists and is the expected type
+        if url.scheme() == "file" {
+            // Ensure the path exists
+            if !path.exists() {
+                bail!("file input `{url}` does not exist");
+            }
+
+            // Check that the result matches the input type
+            match input.ty {
+                IoType::Directory => {
+                    if path.is_file() {
+                        bail!(
+                            "input `{url}` was a file but the input type was `DIRECTORY`",
+                            url = url.display()
+                        );
+                    }
+                }
+                IoType::File => {
+                    if !path.is_file() {
+                        bail!(
+                            "input `{url}` was a directory but the input type was `FILE`",
+                            url = url.display()
+                        );
+                    }
+                }
+            }
+
+            return Ok(());
+        }
+
+        cloud_copy::copy(
+            context.config,
+            context.client,
+            url.clone(),
+            path,
+            context.cancel,
+            Some(context.events),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "failed to download input `{url}` to `{path}`",
+                url = url.display(),
+                path = input.path
+            )
+        })?;
+
+        // Check that the result matches the input type
+        match input.ty {
+            IoType::Directory => {
+                if path.is_file() {
+                    bail!(
+                        "input `{url}` was a file but the input type was `DIRECTORY`",
+                        url = url.display()
+                    );
+                }
+
+                0o555
+            }
+            IoType::File => {
+                if !path.is_file() {
+                    bail!(
+                        "input `{url}` was a directory but the input type was `FILE`",
+                        url = url.display()
+                    );
+                }
+
+                0o444
+            }
+        }
+    };
+
+    // Set the permissions (world-readable) so any user an executor container runs
+    // as will be able to read the input
+    set_permissions(&path, Permissions::from_mode(permissions))
+        .await
+        .with_context(|| {
+            format!(
+                "failed to set permissions for input `{path}`",
+                path = input.path
+            )
+        })?;
+
+    Ok(())
+}
+
 /// Downloads inputs into the inputs directory.
 ///
 /// This will also create empty files and directories for outputs in the outputs
 /// directory.
 async fn download_inputs(
-    config: Config,
+    context: InputTransferContext,
     tes_id: &str,
     orchestrator_dir: &Path,
     inputs_dir: &Path,
     outputs_dir: &Path,
-    cancel: CancellationToken,
+    local_dir: &Path,
 ) -> Result<()> {
     let inputs: Vec<Input> = deserialize_items(inputs_file_path(orchestrator_dir, tes_id))?;
     let outputs: Vec<Output> = deserialize_items(outputs_file_path(orchestrator_dir, tes_id))?;
@@ -293,113 +514,26 @@ async fn download_inputs(
     })?;
 
     // Create an event handling task
-    let (events_tx, events_rx) = broadcast::channel(1000);
-    let c = cancel.clone();
-    let handler = tokio::spawn(async move { handle_events(events_rx, false, c).await });
+    let events = context.events.subscribe();
+    let cancel = context.cancel.clone();
+    let handler = tokio::spawn(async move { handle_events(events, false, cancel).await });
 
-    let files_created = Arc::new(AtomicUsize::new(0));
-
-    let client = HttpClient::new();
-    let created = files_created.clone();
+    // Create a transfer task for downloading each input
+    let ctx = context.clone();
     let transfer = async move || {
         let mut downloads = stream::iter(inputs.into_iter().enumerate())
             .map(|(index, input)| {
-                let path = inputs_dir.join(index.to_string());
-                let cancel = cancel.clone();
-                let config = config.clone();
-                let client = client.clone();
-                let events_tx = events_tx.clone();
-                let created = created.clone();
-                tokio::spawn(async move {
-                    let permissions = if let Some(contents) = &input.content {
-                        // Write the contents if directly given, but only if the input is a file
-                        match input.ty {
-                            IoType::File => {}
-                            IoType::Directory => bail!(
-                                "cannot create content for directory input `{path}`",
-                                path = input.path
-                            ),
-                        }
-
-                        info!(
-                            "creating input file `{path}` with specified contents",
-                            path = input.path,
-                        );
-
-                        tokio::fs::write(&path, contents).await.with_context(|| {
-                            format!("failed to create input file `{path}`", path = input.path)
-                        })?;
-
-                        created.fetch_add(1, Ordering::SeqCst);
-                        0o444
+                let path =
+                    if let Some(sub_path) = input.url.as_deref().and_then(url_to_relative_path) {
+                        local_dir.join(sub_path)
                     } else {
-                        // Perform the cloud copy for a URL
-                        let url = input
-                            .url
-                            .context("input is missing a URL")?
-                            .parse::<Url>()
-                            .context("input URL is invalid")?;
-
-                        cloud_copy::copy(
-                            config,
-                            client.clone(),
-                            url.clone(),
-                            &path,
-                            cancel,
-                            Some(events_tx),
-                        )
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "failed to download input `{url}` to `{path}`",
-                                url = url.display(),
-                                path = input.path
-                            )
-                        })?;
-
-                        // Check that the result matches the input type
-                        match input.ty {
-                            IoType::Directory => {
-                                if path.is_file() {
-                                    bail!(
-                                        "input `{url}` was a file but the input type was \
-                                         `DIRECTORY`",
-                                        url = url.display()
-                                    );
-                                }
-
-                                0o555
-                            }
-                            IoType::File => {
-                                if !path.is_file() {
-                                    bail!(
-                                        "input `{url}` was a directory but the input type was \
-                                         `FILE`",
-                                        url = url.display()
-                                    );
-                                }
-
-                                0o444
-                            }
-                        }
+                        outputs_dir.join(index.to_string())
                     };
-
-                    // Set the permissions (world-readable) so any user an executor container runs
-                    // as will be able to read the input
-                    set_permissions(&path, Permissions::from_mode(permissions))
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "failed to set permissions for input `{path}`",
-                                path = input.path
-                            )
-                        })?;
-
-                    Ok(())
-                })
-                .map(|r| r.expect("task panicked"))
+                let ctx = ctx.clone();
+                tokio::spawn(async move { download_input(ctx, &input, &path).await })
+                    .map(|r| r.expect("task panicked"))
             })
-            .buffer_unordered(config.parallelism());
+            .buffer_unordered(context.config.parallelism());
 
         loop {
             let result = downloads.next().await;
@@ -417,6 +551,7 @@ async fn download_inputs(
     let result = transfer().await;
     let end = Utc::now();
 
+    drop(context.events);
     let stats = handler.await.expect("failed to join events handler");
 
     // Print the statistics upon success
@@ -425,7 +560,7 @@ async fn download_inputs(
     {
         print_stats(
             end - start,
-            files_created.load(Ordering::SeqCst) + stats.files,
+            context.created.load(Ordering::SeqCst) + stats.files,
             stats.bytes,
         );
     }
@@ -435,6 +570,36 @@ async fn download_inputs(
     // We also need to create any file outputs so that Kubernetes will mount them as
     // files and not directories
     for (index, output) in outputs.into_iter().enumerate() {
+        // For local file output URls, just create the file or directory at the expected
+        // output location Executor containers will directly mount it
+        if let Some(path) = url_to_relative_path(&output.url) {
+            let path = local_dir.join(path);
+
+            // Create the parent directory for the output
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!(
+                        "failed to create parent directory of output `{url}`",
+                        url = output.url
+                    )
+                })?;
+            }
+
+            if output.ty == IoType::File {
+                // Create the file
+                File::create(&path).await.with_context(|| {
+                    format!("failed to create output `{url}`", url = output.url)
+                })?;
+            } else {
+                // Create the directory
+                create_dir_all(&path).await.with_context(|| {
+                    format!("failed to create output `{url}`", url = output.url)
+                })?;
+            }
+
+            continue;
+        }
+
         let path = outputs_dir.join(index.to_string());
         let permissions = if output.ty == IoType::File {
             // Create the file
@@ -467,92 +632,109 @@ async fn download_inputs(
     Ok(())
 }
 
+/// Uploads an output at the given path to the requested location.
+async fn upload_output(
+    context: OutputTransferContext,
+    output: &Output,
+    path: &Path,
+) -> Result<Vec<OutputFile>> {
+    let mut url = output.url.parse::<Url>().context("output URL is invalid")?;
+
+    let metadata = path.metadata().with_context(|| {
+        format!(
+            "failed to read metadata of output `{path}`",
+            path = output.path
+        )
+    })?;
+
+    if metadata.is_dir() {
+        return upload_directory(context, output, &url, path).await;
+    }
+
+    if output.ty != IoType::File {
+        bail!(
+            "output `{path}` exists but the output is not a file",
+            path = output.path
+        );
+    }
+
+    // Perform the copy if it isn't a `file://` output
+    if url.scheme() != "file" {
+        info!(
+            "uploading output file `{path}` to `{url}`",
+            path = output.path,
+            url = url.display()
+        );
+
+        cloud_copy::copy(
+            context.config,
+            context.client,
+            path,
+            url.clone(),
+            context.cancel,
+            Some(context.events),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "failed to upload output `{path}` to `{url}`",
+                path = output.path,
+                url = url.display(),
+            )
+        })?;
+    }
+
+    // Clear the query and fragment before saving the output
+    url.set_query(None);
+    url.set_fragment(None);
+
+    Ok(vec![OutputFile {
+        url: url.into(),
+        path: output.path.clone(),
+        size_bytes: metadata.len().to_string(),
+    }])
+}
+
 /// Uploads outputs from the specified outputs directory.
 async fn upload_outputs(
-    config: Config,
+    context: OutputTransferContext,
     tes_id: &str,
     orchestrator_dir: &Path,
     outputs_dir: &Path,
-    cancel: CancellationToken,
+    local_dir: &Path,
 ) -> Result<()> {
     let outputs: Vec<Output> = deserialize_items(outputs_file_path(orchestrator_dir, tes_id))?;
 
     // Create an event handling task
-    let (events_tx, events_rx) = broadcast::channel(1000);
-    let c = cancel.clone();
-    let handler = tokio::spawn(async move { handle_events(events_rx, false, c).await });
+    let events = context.events.subscribe();
+    let cancel = context.cancel.clone();
+    let handler = tokio::spawn(async move { handle_events(events, false, cancel).await });
 
     // Transfer the outputs
-    let client = HttpClient::new();
     let transfer = async || {
         let mut files = Vec::new();
-        for (index, output) in outputs.iter().enumerate() {
-            let mut url = output.url.parse::<Url>().context("output URL is invalid")?;
-            let path = outputs_dir.join(index.to_string());
-            let metadata = path.metadata().with_context(|| {
-                format!(
-                    "failed to read metadata of output `{path}`",
-                    path = output.path
-                )
-            })?;
+        let mut uploads = stream::iter(outputs.into_iter().enumerate())
+            .map(|(index, output)| {
+                let path = if let Some(sub_path) = output.url.strip_prefix("file:///") {
+                    local_dir.join(sub_path)
+                } else {
+                    outputs_dir.join(index.to_string())
+                };
+                let ctx = context.clone();
+                tokio::spawn(async move { upload_output(ctx, &output, &path).await })
+                    .map(|r| r.expect("task panicked"))
+            })
+            .buffer_unordered(context.config.parallelism());
 
-            let path = path
-                .to_str()
-                .with_context(|| format!("path `{path}` is not UTF-8", path = path.display()))?;
-
-            if metadata.is_dir() {
-                files.extend(
-                    upload_directory(
-                        config.clone(),
-                        client.clone(),
-                        output,
-                        &url,
-                        path,
-                        Some(events_tx.clone()),
-                        cancel.clone(),
-                    )
-                    .await?,
-                );
-                continue;
+        loop {
+            let result = uploads.next().await;
+            match result {
+                Some(r) => files.extend(r?),
+                None => break,
             }
-
-            if output.ty != IoType::File {
-                bail!(
-                    "output `{path}` exists but the output is not a file",
-                    path = output.path
-                );
-            }
-
-            // Perform the copy
-            cloud_copy::copy(
-                config.clone(),
-                client.clone(),
-                path,
-                url.clone(),
-                cancel.clone(),
-                Some(events_tx.clone()),
-            )
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to upload output `{path}` to `{url}`",
-                    path = output.path,
-                    url = url.display(),
-                )
-            })?;
-
-            // Clear the query and fragment before saving the output
-            url.set_query(None);
-            url.set_fragment(None);
-
-            files.push(OutputFile {
-                url: url.as_str().to_string(),
-                path: output.path.clone(),
-                size_bytes: metadata.len().to_string(),
-            });
         }
 
-        Ok(files)
+        anyhow::Ok(files)
     };
 
     // Perform the transfer
@@ -560,7 +742,7 @@ async fn upload_outputs(
     let result = transfer().await;
     let end = Utc::now();
 
-    drop(events_tx);
+    drop(context.events);
     let stats = handler.await.expect("failed to join events handler");
 
     let outputs = result?;
@@ -581,13 +763,10 @@ async fn upload_outputs(
 
 /// Uploads a directory output.
 async fn upload_directory(
-    config: Config,
-    client: HttpClient,
+    context: OutputTransferContext,
     output: &Output,
     url: &Url,
-    path: &str,
-    events: Option<broadcast::Sender<TransferEvent>>,
-    cancel: CancellationToken,
+    directory: &Path,
 ) -> Result<Vec<OutputFile>> {
     if output.ty != IoType::Directory {
         bail!(
@@ -606,11 +785,14 @@ async fn upload_directory(
         };
 
     let mut files = Vec::new();
-    for entry in WalkDir::new(path) {
+    for entry in WalkDir::new(directory) {
         let entry = entry
             .with_context(|| format!("failed to read directory `{path}`", path = output.path))?;
 
-        let relative_path = entry.path().strip_prefix(path).expect("should be relative");
+        let relative_path = entry
+            .path()
+            .strip_prefix(directory)
+            .expect("should be relative");
         let container_path = container_base_path.join(relative_path);
         let container_path = container_path.to_str().with_context(|| {
             format!(
@@ -635,13 +817,7 @@ async fn upload_directory(
             continue;
         }
 
-        info!(
-            "uploading output file `{container_path}` to `{url}`",
-            url = url.display()
-        );
-
         let mut url = url.clone();
-
         {
             // Append the relative path to the URL
             let mut segments = url.path_segments_mut().unwrap();
@@ -658,29 +834,36 @@ async fn upload_directory(
             }
         }
 
-        // Perform the copy
-        cloud_copy::copy(
-            config.clone(),
-            client.clone(),
-            entry.path(),
-            url.clone(),
-            cancel.clone(),
-            events.clone(),
-        )
-        .await
-        .with_context(|| {
-            format!(
-                "failed to upload output `{container_path}` to `{url}`",
-                url = url.display(),
+        // Perform the copy if it isn't a `file://` output
+        if url.scheme() != "file" {
+            info!(
+                "uploading output file `{container_path}` to `{url}`",
+                url = url.display()
+            );
+
+            cloud_copy::copy(
+                context.config.clone(),
+                context.client.clone(),
+                entry.path(),
+                url.clone(),
+                context.cancel.clone(),
+                Some(context.events.clone()),
             )
-        })?;
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to upload output `{container_path}` to `{url}`",
+                    url = url.display(),
+                )
+            })?;
+        }
 
         // Clear the query and fragment before saving the output
         url.set_query(None);
         url.set_fragment(None);
 
         files.push(OutputFile {
-            url: url.as_str().to_string(),
+            url: url.into(),
             path: container_path.to_string(),
             size_bytes: metadata.len().to_string(),
         });
@@ -784,23 +967,25 @@ async fn run(cancel: CancellationToken) -> Result<()> {
 
     match args.mode {
         Mode::Inputs => {
+            let context = InputTransferContext::new(config, cancel);
             download_inputs(
-                config,
+                context,
                 &args.tes_id,
                 &args.orchestrator_dir,
                 &args.inputs_dir.expect("option should be present"),
                 &args.outputs_dir,
-                cancel,
+                &args.local_dir,
             )
             .await
         }
         Mode::Outputs => {
+            let context = OutputTransferContext::new(config, cancel);
             upload_outputs(
-                config,
+                context,
                 &args.tes_id,
                 &args.orchestrator_dir,
                 &args.outputs_dir,
-                cancel,
+                &args.local_dir,
             )
             .await
         }

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -803,7 +803,8 @@ async fn prepare_directory_output(
 ///
 /// Each remote output is uploaded to cloud storage.
 ///
-/// Responsible for writing the `outputs.json`
+/// Responsible for creating the `files.json` file for the task that is read by
+/// the orchestrator.
 async fn prepare_outputs(
     context: TransferContext,
     tes_id: &str,

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -502,11 +502,8 @@ async fn prepare_inputs(
                         && let Some(path) = url_to_file_path(url)
                     {
                         match local_dir {
-                            Some(local_dir) => {
-                                local_dir.join(path.strip_prefix("/").with_context(|| {
-                                    format!("input URL `{url}` is not absolute")
-                                })?)
-                            }
+                            Some(local_dir) => local_dir
+                                .join(path.strip_prefix("/").expect("path should be absolute")),
                             None => bail!("input file URL `{url}` is not supported"),
                         }
                     } else {
@@ -546,9 +543,9 @@ async fn prepare_inputs(
         // expected output location; executor containers will mount it directly.
         if let Some(path) = url_to_file_path(&output.url) {
             let path = match local_dir {
-                Some(local_dir) => local_dir.join(path.strip_prefix("/").with_context(|| {
-                    format!("output URL `{url}` is not absolute", url = output.url)
-                })?),
+                Some(local_dir) => {
+                    local_dir.join(path.strip_prefix("/").expect("path should be absolute"))
+                }
                 None => bail!("output file URL `{url}` is not supported", url = output.url),
             };
 
@@ -830,11 +827,8 @@ async fn prepare_outputs(
                 tokio::spawn(async move {
                     let path = if let Some(path) = url_to_file_path(&output.url) {
                         match local_dir {
-                            Some(local_dir) => {
-                                local_dir.join(path.strip_prefix("/").with_context(|| {
-                                    format!("output URL `{url}` is not absolute", url = output.url)
-                                })?)
-                            }
+                            Some(local_dir) => local_dir
+                                .join(path.strip_prefix("/").expect("path should be absolute")),
                             None => {
                                 bail!("output file URL `{url}` is not supported", url = output.url)
                             }

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -570,8 +570,8 @@ async fn download_inputs(
     // We also need to create any file outputs so that Kubernetes will mount them as
     // files and not directories
     for (index, output) in outputs.into_iter().enumerate() {
-        // For local file output URls, just create the file or directory at the expected
-        // output location Executor containers will directly mount it
+        // For local `file://` output URLs, create the file or directory at the
+        // expected output location; executor containers will mount it directly.
         if let Some(path) = url_to_relative_path(&output.url) {
             let path = local_dir.join(path);
 

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -527,7 +527,7 @@ async fn download_inputs(
                     if let Some(sub_path) = input.url.as_deref().and_then(url_to_relative_path) {
                         local_dir.join(sub_path)
                     } else {
-                        outputs_dir.join(index.to_string())
+                        inputs_dir.join(index.to_string())
                     };
                 let ctx = ctx.clone();
                 tokio::spawn(async move { download_input(ctx, &input, &path).await })


### PR DESCRIPTION
This commit implements support for `file://` schemed URLs for inputs and outputs in TES tasks.

To support this feature, cluster administrators provide a shared volume definition to provide the local storage.

Planetary will map `file://` schemed URLs to the appropriate path within the shared volume and provide explicit mounts for the inputs and outputs to the executor containers.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

Repository specific checklist:

- [x] If you update the supported TES version, you should change the version at
      `planetary::server::TES_VERSION`.
- [x] Make sure that (a) none of the changes conflict with information we lay 
      out in the "Security Notice" section of the `README.md` and (b) anything
      that needs to be added to that section is added.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
