### PR TITLE
feat: include error output in system log from i/o containers.

### DIFF
--- a/api/src/tasks.rs
+++ b/api/src/tasks.rs
@@ -17,7 +17,7 @@ pub fn router(allow_authorization_fallback: bool) -> Router<State> {
         .route("/v1/tasks", post(v1::create_task))
         .route("/v1/tasks/{id}", get(v1::get_task))
         // TODO: the path should be `/v1/tasks/{id}:cancel`, but that's not supported until
-        // `matchit`` 0.8.6; we're currently on 0.8.4 via `axum`
+        // `matchit` 0.8.6; we're currently on 0.8.4 via `axum`
         .route("/v1/tasks/{id}", post(v1::cancel_task))
         .layer(middleware::from_fn(move |a, r, n| {
             crate::auth(allow_authorization_fallback, a, r, n)

--- a/db/CHANGELOG.md
+++ b/db/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added `name` column to containers table ([#43](https://github.com/stjude-rust-labs/planetary/pull/43)).
 * Added support retrieving usernames of tasks for template rendering ([#41](https://github.com/stjude-rust-labs/planetary/pull/41)).
 * Added `username` column to `tasks` table to associate tasks with TES API
   users ([#40](https://github.com/stjude-rust-labs/planetary/pull/40)).

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1,7 +1,6 @@
 //! Implementation of database support for Planetary.
 
 use std::borrow::Cow;
-use std::fmt;
 
 use anyhow::Result;
 use chrono::DateTime;
@@ -18,6 +17,19 @@ use tes::v1::types::task::Executor;
 use tes::v1::types::task::Input;
 use tes::v1::types::task::Output;
 use tes::v1::types::task::State;
+
+/// Helper macro for exposing the prefix constant and for joining with `%` in
+/// `like` clauses.
+///
+/// This is necessary because `concat!` only supports literals.
+macro_rules! _EXECUTOR_CONTAINER_PREFIX {
+    () => {
+        "executor-"
+    };
+}
+
+/// The expected prefix for executor container names.
+pub const EXECUTOR_CONTAINER_PREFIX: &str = _EXECUTOR_CONTAINER_PREFIX!();
 
 #[cfg(feature = "postgres")]
 pub mod postgres;
@@ -49,36 +61,11 @@ pub struct TaskIo {
     pub outputs: Vec<Output>,
 }
 
-/// Represents a kind of container.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ContainerKind {
-    /// The container is for downloading a task's inputs.
-    Inputs,
-    /// The container is a task executor.
-    Executor,
-    /// The container is for uploading a task's outputs.
-    Outputs,
-}
-
-impl fmt::Display for ContainerKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Inputs => write!(f, "inputs"),
-            Self::Executor => write!(f, "executor"),
-            Self::Outputs => write!(f, "outputs"),
-        }
-    }
-}
-
 /// Represents information about a terminated container.
 #[derive(Debug, Clone)]
 pub struct TerminatedContainer<'a> {
-    /// The kind of the container.
-    pub kind: ContainerKind,
-    /// The index of the executor.
-    ///
-    /// This is `None` when the container was not an executor.
-    pub executor_index: Option<i32>,
+    /// The name of the container.
+    pub name: &'a str,
     /// The start time of the container.
     pub start_time: DateTime<Utc>,
     /// The end time of the container.

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -18,18 +18,11 @@ use tes::v1::types::task::Input;
 use tes::v1::types::task::Output;
 use tes::v1::types::task::State;
 
-/// Helper macro for exposing the prefix constant and for joining with `%` in
-/// `like` clauses.
-///
-/// This is necessary because `concat!` only supports literals.
-macro_rules! _EXECUTOR_CONTAINER_PREFIX {
-    () => {
-        "executor-"
-    };
-}
-
 /// The expected prefix for executor container names.
-pub const EXECUTOR_CONTAINER_PREFIX: &str = _EXECUTOR_CONTAINER_PREFIX!();
+pub const EXECUTOR_CONTAINER_PREFIX: &str = "executor-";
+
+/// The expected LIKE pattern for executor container names.
+pub const EXECUTOR_CONTAINER_PATTERN: &str = "executor-%";
 
 #[cfg(feature = "postgres")]
 pub mod postgres;

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -18,12 +18,6 @@ use tes::v1::types::task::Input;
 use tes::v1::types::task::Output;
 use tes::v1::types::task::State;
 
-/// The expected prefix for executor container names.
-pub const EXECUTOR_CONTAINER_PREFIX: &str = "executor-";
-
-/// The expected LIKE pattern for executor container names.
-pub const EXECUTOR_CONTAINER_PATTERN: &str = "executor-%";
-
 #[cfg(feature = "postgres")]
 pub mod postgres;
 
@@ -59,6 +53,10 @@ pub struct TaskIo {
 pub struct TerminatedContainer<'a> {
     /// The name of the container.
     pub name: &'a str,
+    /// The index of the executor.
+    ///
+    /// This is `None` when the container was not an executor.
+    pub executor_index: Option<i32>,
     /// The start time of the container.
     pub start_time: DateTime<Utc>,
     /// The end time of the container.

--- a/db/src/postgres.rs
+++ b/db/src/postgres.rs
@@ -265,8 +265,11 @@ impl Database for PostgresDatabase {
 
                 let containers = models::BasicContainer::belonging_to(&task)
                     .select(models::BasicContainer::as_select())
-                    .filter(schema::containers::executor_index.is_not_null())
-                    .order_by(schema::containers::executor_index)
+                    .filter(
+                        schema::containers::name.like(concat!(_EXECUTOR_CONTAINER_PREFIX!(), "%")),
+                    )
+                    .order_by(schema::containers::id)
+                    .order_by(schema::containers::id)
                     .load(&mut conn)
                     .await
                     .map_err(Error::Diesel)?;
@@ -289,8 +292,10 @@ impl Database for PostgresDatabase {
 
                 let containers = models::FullContainer::belonging_to(&task)
                     .select(models::FullContainer::as_select())
-                    .filter(schema::containers::executor_index.is_not_null())
-                    .order_by(schema::containers::executor_index)
+                    .filter(
+                        schema::containers::name.like(concat!(_EXECUTOR_CONTAINER_PREFIX!(), "%")),
+                    )
+                    .order_by(schema::containers::id)
                     .load(&mut conn)
                     .await
                     .map_err(Error::Diesel)?;
@@ -414,8 +419,11 @@ impl Database for PostgresDatabase {
                 Ok((
                     models::BasicContainer::belonging_to(&tasks)
                         .select(models::BasicContainer::as_select())
-                        .filter(schema::containers::executor_index.is_not_null())
-                        .order_by(schema::containers::executor_index)
+                        .filter(
+                            schema::containers::name
+                                .like(concat!(_EXECUTOR_CONTAINER_PREFIX!(), "%")),
+                        )
+                        .order_by(schema::containers::id)
                         .load(&mut conn)
                         .await
                         .map_err(Error::Diesel)?
@@ -445,8 +453,11 @@ impl Database for PostgresDatabase {
                 Ok((
                     models::FullContainer::belonging_to(&tasks)
                         .select(models::FullContainer::as_select())
-                        .filter(schema::containers::executor_index.is_not_null())
-                        .order_by(schema::containers::executor_index)
+                        .filter(
+                            schema::containers::name
+                                .like(concat!(_EXECUTOR_CONTAINER_PREFIX!(), "%")),
+                        )
+                        .order_by(schema::containers::id)
                         .load(&mut conn)
                         .await
                         .map_err(Error::Diesel)?

--- a/db/src/postgres.rs
+++ b/db/src/postgres.rs
@@ -36,7 +36,6 @@ use tracing::info;
 
 use super::Database;
 use super::DatabaseResult;
-use crate::EXECUTOR_CONTAINER_PATTERN;
 use crate::TaskTemplateData;
 use crate::TerminatedContainer;
 
@@ -266,8 +265,8 @@ impl Database for PostgresDatabase {
 
                 let containers = models::BasicContainer::belonging_to(&task)
                     .select(models::BasicContainer::as_select())
-                    .filter(schema::containers::name.like(EXECUTOR_CONTAINER_PATTERN))
-                    .order_by(schema::containers::name)
+                    .filter(schema::containers::executor_index.is_not_null())
+                    .order_by(schema::containers::executor_index)
                     .load(&mut conn)
                     .await
                     .map_err(Error::Diesel)?;
@@ -290,8 +289,8 @@ impl Database for PostgresDatabase {
 
                 let containers = models::FullContainer::belonging_to(&task)
                     .select(models::FullContainer::as_select())
-                    .filter(schema::containers::name.like(EXECUTOR_CONTAINER_PATTERN))
-                    .order_by(schema::containers::name)
+                    .filter(schema::containers::executor_index.is_not_null())
+                    .order_by(schema::containers::executor_index)
                     .load(&mut conn)
                     .await
                     .map_err(Error::Diesel)?;
@@ -415,8 +414,8 @@ impl Database for PostgresDatabase {
                 Ok((
                     models::BasicContainer::belonging_to(&tasks)
                         .select(models::BasicContainer::as_select())
-                        .filter(schema::containers::name.like(EXECUTOR_CONTAINER_PATTERN))
-                        .order_by(schema::containers::name)
+                        .filter(schema::containers::executor_index.is_not_null())
+                        .order_by(schema::containers::executor_index)
                         .load(&mut conn)
                         .await
                         .map_err(Error::Diesel)?
@@ -446,8 +445,8 @@ impl Database for PostgresDatabase {
                 Ok((
                     models::FullContainer::belonging_to(&tasks)
                         .select(models::FullContainer::as_select())
-                        .filter(schema::containers::name.like(EXECUTOR_CONTAINER_PATTERN))
-                        .order_by(schema::containers::name)
+                        .filter(schema::containers::executor_index.is_not_null())
+                        .order_by(schema::containers::executor_index)
                         .load(&mut conn)
                         .await
                         .map_err(Error::Diesel)?

--- a/db/src/postgres.rs
+++ b/db/src/postgres.rs
@@ -36,6 +36,7 @@ use tracing::info;
 
 use super::Database;
 use super::DatabaseResult;
+use crate::EXECUTOR_CONTAINER_PATTERN;
 use crate::TaskTemplateData;
 use crate::TerminatedContainer;
 
@@ -265,11 +266,8 @@ impl Database for PostgresDatabase {
 
                 let containers = models::BasicContainer::belonging_to(&task)
                     .select(models::BasicContainer::as_select())
-                    .filter(
-                        schema::containers::name.like(concat!(_EXECUTOR_CONTAINER_PREFIX!(), "%")),
-                    )
-                    .order_by(schema::containers::id)
-                    .order_by(schema::containers::id)
+                    .filter(schema::containers::name.like(EXECUTOR_CONTAINER_PATTERN))
+                    .order_by(schema::containers::name)
                     .load(&mut conn)
                     .await
                     .map_err(Error::Diesel)?;
@@ -292,10 +290,8 @@ impl Database for PostgresDatabase {
 
                 let containers = models::FullContainer::belonging_to(&task)
                     .select(models::FullContainer::as_select())
-                    .filter(
-                        schema::containers::name.like(concat!(_EXECUTOR_CONTAINER_PREFIX!(), "%")),
-                    )
-                    .order_by(schema::containers::id)
+                    .filter(schema::containers::name.like(EXECUTOR_CONTAINER_PATTERN))
+                    .order_by(schema::containers::name)
                     .load(&mut conn)
                     .await
                     .map_err(Error::Diesel)?;
@@ -419,11 +415,8 @@ impl Database for PostgresDatabase {
                 Ok((
                     models::BasicContainer::belonging_to(&tasks)
                         .select(models::BasicContainer::as_select())
-                        .filter(
-                            schema::containers::name
-                                .like(concat!(_EXECUTOR_CONTAINER_PREFIX!(), "%")),
-                        )
-                        .order_by(schema::containers::id)
+                        .filter(schema::containers::name.like(EXECUTOR_CONTAINER_PATTERN))
+                        .order_by(schema::containers::name)
                         .load(&mut conn)
                         .await
                         .map_err(Error::Diesel)?
@@ -453,11 +446,8 @@ impl Database for PostgresDatabase {
                 Ok((
                     models::FullContainer::belonging_to(&tasks)
                         .select(models::FullContainer::as_select())
-                        .filter(
-                            schema::containers::name
-                                .like(concat!(_EXECUTOR_CONTAINER_PREFIX!(), "%")),
-                        )
-                        .order_by(schema::containers::id)
+                        .filter(schema::containers::name.like(EXECUTOR_CONTAINER_PATTERN))
+                        .order_by(schema::containers::name)
                         .load(&mut conn)
                         .await
                         .map_err(Error::Diesel)?

--- a/db/src/postgres/migrations/2025-05-12-172231_initial/down.sql
+++ b/db/src/postgres/migrations/2025-05-12-172231_initial/down.sql
@@ -1,5 +1,4 @@
 DROP TABLE errors;
 DROP TABLE containers;
-DROP TYPE container_kind;
 DROP TABLE tasks;
 DROP TYPE task_state;

--- a/db/src/postgres/migrations/2025-05-12-172231_initial/up.sql
+++ b/db/src/postgres/migrations/2025-05-12-172231_initial/up.sql
@@ -58,6 +58,7 @@ CREATE TABLE containers (
     id SERIAL PRIMARY KEY,
     task_id INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
+    executor_index INTEGER NULL,
     start_time TIMESTAMPTZ NOT NULL,
     end_time TIMESTAMPTZ NOT NULL,
     stdout TEXT NULL,

--- a/db/src/postgres/migrations/2025-05-12-172231_initial/up.sql
+++ b/db/src/postgres/migrations/2025-05-12-172231_initial/up.sql
@@ -51,21 +51,13 @@ CREATE INDEX idx_tasks_state ON tasks (state);
 -- Create an index on the `tags` column for list operations.
 CREATE INDEX idx_tasks_tags ON tasks USING gin (tags);
 
--- An enumeration for container kind.
-CREATE TYPE container_kind AS ENUM(
-    'INPUTS',
-    'EXECUTOR',
-    'OUTPUTS'
-);
-
 -- The containers table.
 -- This table keeps track of the individual containers used to run a task.
 -- An entry is inserted into this table when the container has completed.
 CREATE TABLE containers (
     id SERIAL PRIMARY KEY,
     task_id INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-    kind container_kind NOT NULL,
-    executor_index INTEGER NULL,
+    name TEXT NOT NULL,
     start_time TIMESTAMPTZ NOT NULL,
     end_time TIMESTAMPTZ NOT NULL,
     stdout TEXT NULL,

--- a/db/src/postgres/models.rs
+++ b/db/src/postgres/models.rs
@@ -515,43 +515,6 @@ impl From<TaskTemplateData> for crate::TaskTemplateData {
     }
 }
 
-/// Represents the kind of a container.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, diesel_derive_enum::DbEnum)]
-#[db_enum(
-    existing_type_path = "crate::postgres::schema::sql_types::ContainerKind",
-    value_style = "SCREAMING_SNAKE_CASE"
-)]
-pub enum ContainerKind {
-    /// The container is for downloading a task's inputs.
-    Inputs,
-    /// The container is a task executor.
-    Executor,
-    /// The container is for uploading a task's outputs.
-    Outputs,
-}
-
-impl From<ContainerKind> for crate::ContainerKind {
-    fn from(kind: ContainerKind) -> Self {
-        match kind {
-            ContainerKind::Inputs => Self::Inputs,
-            ContainerKind::Executor => Self::Executor,
-            ContainerKind::Outputs => Self::Outputs,
-        }
-    }
-}
-
-impl From<crate::ContainerKind> for ContainerKind {
-    fn from(kind: crate::ContainerKind) -> Self {
-        use crate::ContainerKind::*;
-
-        match kind {
-            Inputs => Self::Inputs,
-            Executor => Self::Executor,
-            Outputs => Self::Outputs,
-        }
-    }
-}
-
 /// Used to insert a new container into the containers table.
 #[derive(Insertable)]
 #[diesel(table_name = super::schema::containers)]
@@ -560,11 +523,7 @@ pub struct NewContainer<'a> {
     /// The task id of the container.
     pub task_id: i32,
     /// The name of the container.
-    pub kind: ContainerKind,
-    /// The executor index of the container.
-    ///
-    /// This is `NULL` for input and output containers.
-    pub executor_index: Option<i32>,
+    pub name: &'a str,
     /// The start time for the container.
     pub start_time: DateTime<Utc>,
     /// The end time for the container.
@@ -583,8 +542,7 @@ impl<'a> NewContainer<'a> {
     pub fn new(task_id: i32, container: crate::TerminatedContainer<'a>) -> Self {
         Self {
             task_id,
-            kind: container.kind.into(),
-            executor_index: container.executor_index,
+            name: container.name,
             start_time: container.start_time,
             end_time: container.end_time,
             stdout: container.stdout,

--- a/db/src/postgres/models.rs
+++ b/db/src/postgres/models.rs
@@ -524,6 +524,10 @@ pub struct NewContainer<'a> {
     pub task_id: i32,
     /// The name of the container.
     pub name: &'a str,
+    /// The executor index of the container.
+    ///
+    /// This is `NULL` for input and output containers.
+    pub executor_index: Option<i32>,
     /// The start time for the container.
     pub start_time: DateTime<Utc>,
     /// The end time for the container.
@@ -543,6 +547,7 @@ impl<'a> NewContainer<'a> {
         Self {
             task_id,
             name: container.name,
+            executor_index: container.executor_index,
             start_time: container.start_time,
             end_time: container.end_time,
             stdout: container.stdout,

--- a/db/src/postgres/schema.rs
+++ b/db/src/postgres/schema.rs
@@ -2,23 +2,15 @@
 
 pub mod sql_types {
     #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
-    #[diesel(postgres_type(name = "container_kind"))]
-    pub struct ContainerKind;
-
-    #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "task_state"))]
     pub struct TaskState;
 }
 
 diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::ContainerKind;
-
     containers (id) {
         id -> Int4,
         task_id -> Int4,
-        kind -> ContainerKind,
-        executor_index -> Nullable<Int4>,
+        name -> Text,
         start_time -> Timestamptz,
         end_time -> Timestamptz,
         stdout -> Nullable<Text>,

--- a/db/src/postgres/schema.rs
+++ b/db/src/postgres/schema.rs
@@ -11,6 +11,7 @@ diesel::table! {
         id -> Int4,
         task_id -> Int4,
         name -> Text,
+        executor_index -> Nullable<Int4>,
         start_time -> Timestamptz,
         end_time -> Timestamptz,
         stdout -> Nullable<Text>,

--- a/orchestrator/CHANGELOG.md
+++ b/orchestrator/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Orchestrator now includes the output of the inputs or outputs container in
+  the task's system log when they fail ([#43](https://github.com/stjude-rust-labs/planetary/pull/43)).
 * Added creating Kubernetes resources via a template ([#38](https://github.com/stjude-rust-labs/planetary/pull/38)).
 * Added shared storage for communicating inputs and outputs to task pods ([#38](https://github.com/stjude-rust-labs/planetary/pull/38)).
 * Added support for reading Azure Storage credentials from the K8s secret ([#27](https://github.com/stjude-rust-labs/planetary/pull/27)).

--- a/orchestrator/src/orchestrator.rs
+++ b/orchestrator/src/orchestrator.rs
@@ -41,7 +41,6 @@ use kube::runtime::reflector::Lookup;
 use kube::runtime::watcher;
 use kube::runtime::watcher::Event;
 use planetary_db::Database;
-use planetary_db::EXECUTOR_CONTAINER_PREFIX;
 use planetary_db::TerminatedContainer;
 use planetary_db::format_log_message;
 use planetary_server::templating::CANCELED_LABEL;
@@ -108,6 +107,9 @@ const INPUTS_CONTAINER_NAME: &str = "inputs";
 
 /// The expected container name for transporting outputs.
 const OUTPUTS_CONTAINER_NAME: &str = "outputs";
+
+/// The expected prefix for executor container names.
+pub const EXECUTOR_CONTAINER_PREFIX: &str = "executor-";
 
 /// Gets the task directory path for a TES task.
 fn task_directory_path(tes_id: &str) -> PathBuf {
@@ -276,6 +278,12 @@ fn format_executor_script(executor: &Executor) -> Result<String> {
     // not be flushed
     script.push_str("wait $(jobs -p) 2>&1 >/dev/null");
     Ok(script)
+}
+
+/// Gets the executor index given a container name.
+fn executor_index(name: &str) -> Option<i32> {
+    name.strip_prefix(EXECUTOR_CONTAINER_PREFIX)
+        .and_then(|n| n.parse().ok())
 }
 
 /// Used to determine what state a task pod is in.
@@ -1104,9 +1112,11 @@ impl TaskOrchestrator {
             )
             .await?;
 
+            let executor_index = executor_index(&status.name);
+
             // If the output contains the magic exit prefix, use the contained exit code
             // rather than the containers
-            let exit_code = if status.name.starts_with(EXECUTOR_CONTAINER_PREFIX)
+            let exit_code = if executor_index.is_some()
                 && let Some(pos) = output.rfind(EXIT_PREFIX)
             {
                 let exit = output.split_off(pos);
@@ -1127,6 +1137,7 @@ impl TaskOrchestrator {
 
             containers.push(TerminatedContainer {
                 name: &status.name,
+                executor_index,
                 start_time: DateTime::from_timestamp_micros(
                     terminated
                         .started_at

--- a/orchestrator/src/orchestrator.rs
+++ b/orchestrator/src/orchestrator.rs
@@ -40,8 +40,8 @@ use kube::runtime::WatchStreamExt;
 use kube::runtime::reflector::Lookup;
 use kube::runtime::watcher;
 use kube::runtime::watcher::Event;
-use planetary_db::ContainerKind;
 use planetary_db::Database;
+use planetary_db::EXECUTOR_CONTAINER_PREFIX;
 use planetary_db::TerminatedContainer;
 use planetary_db::format_log_message;
 use planetary_server::templating::CANCELED_LABEL;
@@ -81,11 +81,11 @@ use crate::retry_durations;
 /// state.
 const ORCHESTRATOR_MOUNT: &str = "/mnt/orchestrator";
 
-/// The maximum number of lines to tail for an executor pod's logs.
+/// The maximum number of lines to tail for a task pod container.
 ///
 /// This is 16 because there is always an extra line of output in the executor's
 /// log to maybe contain the executors real exit code.
-const MAX_EXECUTOR_LOG_LINES: i64 = 16;
+const MAX_LOG_LINES: i64 = 16;
 
 /// The reason for an image pull backoff wait.
 const IMAGE_PULL_BACKOFF_REASON: &str = "ImagePullBackOff";
@@ -103,17 +103,11 @@ const IMAGE_PULL_BACKOFF_REASON: &str = "ImagePullBackOff";
 /// exit code.
 const EXIT_PREFIX: &str = "exit: ";
 
-/// Formats a container name given the container kind.
-fn format_container_name(kind: ContainerKind, executor_index: Option<usize>) -> String {
-    match kind {
-        ContainerKind::Inputs => "inputs".into(),
-        ContainerKind::Executor => format!(
-            "executor-{index}",
-            index = executor_index.expect("should have index")
-        ),
-        ContainerKind::Outputs => "outputs".into(),
-    }
-}
+/// The expected container name for transporting inputs.
+const INPUTS_CONTAINER_NAME: &str = "inputs";
+
+/// The expected container name for transporting outputs.
+const OUTPUTS_CONTAINER_NAME: &str = "outputs";
 
 /// Gets the task directory path for a TES task.
 fn task_directory_path(tes_id: &str) -> PathBuf {
@@ -297,9 +291,13 @@ enum TaskPodState<'a> {
     Running,
     /// The pod succeeded and the task is complete.
     Succeeded,
+    /// The inputs container has failed.
+    InputsError,
     /// The pod failed due to executor error (exited with non-zero).
     ExecutorError(usize),
-    /// The pod failed due to system error.
+    /// The outputs container has failed.
+    OutputsError,
+    /// The pod failed due to an unspecified system error.
     SystemError,
     /// The pod failed to pull its image and has backed off.
     ImagePullBackOff(&'a str),
@@ -313,7 +311,9 @@ impl fmt::Display for TaskPodState<'_> {
             Self::Initializing => write!(f, "initializing"),
             Self::Running => write!(f, "running"),
             Self::Succeeded => write!(f, "succeeded"),
+            Self::InputsError => write!(f, "inputs error"),
             Self::ExecutorError(_) => write!(f, "executor error"),
+            Self::OutputsError => write!(f, "outputs error"),
             Self::SystemError => write!(f, "system error"),
             Self::ImagePullBackOff(_) => write!(f, "image pull backoff"),
         }
@@ -405,20 +405,35 @@ impl PodExt for Pod {
             "Running" => TaskPodState::Running,
             "Succeeded" => TaskPodState::Succeeded,
             "Failed" => {
-                let init_statuses = status
+                // Search for the failed container
+                if let Some(failed) = status
                     .init_container_statuses
                     .as_deref()
-                    .unwrap_or_default();
-
-                // Check for any failed executor
-                if let Some(index) = init_statuses.iter().position(|s| {
-                    s.state
-                        .as_ref()
-                        .and_then(|s| s.terminated.as_ref().map(|s| s.exit_code != 0))
-                        .unwrap_or(false)
-                }) && index > 0
+                    .unwrap_or_default()
+                    .iter()
+                    .chain(status.container_statuses.as_deref().unwrap_or_default())
+                    .find(|s| {
+                        s.state
+                            .as_ref()
+                            .and_then(|s| s.terminated.as_ref().map(|s| s.exit_code != 0))
+                            .unwrap_or(false)
+                    })
                 {
-                    return Ok(TaskPodState::ExecutorError(index - 1));
+                    if failed.name == INPUTS_CONTAINER_NAME {
+                        return Ok(TaskPodState::InputsError);
+                    }
+
+                    if failed.name == OUTPUTS_CONTAINER_NAME {
+                        return Ok(TaskPodState::OutputsError);
+                    }
+
+                    if let Some(index) = failed
+                        .name
+                        .strip_prefix(EXECUTOR_CONTAINER_PREFIX)
+                        .and_then(|n| n.parse().ok())
+                    {
+                        return Ok(TaskPodState::ExecutorError(index));
+                    }
                 }
 
                 TaskPodState::SystemError
@@ -752,9 +767,11 @@ impl TaskOrchestrator {
             TaskPodState::Initializing => self.handle_initializing_task(tes_id).await?,
             TaskPodState::Running => self.handle_running_task(tes_id).await?,
             TaskPodState::Succeeded => self.handle_succeeded_task(tes_id, pod).await?,
+            TaskPodState::InputsError => self.handle_io_error(tes_id, pod, true).await?,
             TaskPodState::ExecutorError(index) => {
                 self.handle_executor_error(tes_id, index, pod).await?
             }
+            TaskPodState::OutputsError => self.handle_io_error(tes_id, pod, false).await?,
             TaskPodState::SystemError => self.handle_system_error(tes_id, pod).await?,
             TaskPodState::ImagePullBackOff(message) => {
                 self.handle_image_pull_backoff(tes_id, message, pod).await?
@@ -842,6 +859,70 @@ impl TaskOrchestrator {
         Ok(())
     }
 
+    /// Handles an error for processing inputs or outputs.
+    async fn handle_io_error(&self, tes_id: &str, pod: &Pod, inputs: bool) -> Result<(), Error> {
+        let name = pod.name().context("pod is missing a name")?;
+        let ns = pod.namespace().context("pod is missing a namespace")?;
+        let pods: Api<Pod> = Api::namespaced(self.client.clone(), &ns);
+
+        // Get the input container's output to record in the system log
+        let output = Retry::spawn_notify(
+            retry_durations(),
+            || async {
+                match pods
+                    .logs(
+                        &name,
+                        &LogParams {
+                            container: Some(
+                                if inputs {
+                                    INPUTS_CONTAINER_NAME
+                                } else {
+                                    OUTPUTS_CONTAINER_NAME
+                                }
+                                .to_string(),
+                            ),
+                            tail_lines: Some(MAX_LOG_LINES),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                {
+                    Ok(output) => Ok(output),
+                    Err(kube::Error::Api(s)) if s.is_not_found() || s.code == 400 => {
+                        // The pod or container no longer exists; treat as empty output
+                        Ok(String::new())
+                    }
+                    Err(e) => Err(into_retry_error(e)),
+                }
+            },
+            notify_retry,
+        )
+        .await?;
+
+        let message = format_log_message!(
+            "task `{tes_id}` has failed due to an error encountered while processing {kind} (last \
+             {MAX_LOG_LINES} lines of output):\n{output}",
+            kind = if inputs { "inputs" } else { "outputs" },
+            output = output.trim()
+        );
+
+        if self
+            .database
+            .update_task_state(
+                tes_id,
+                State::SystemError,
+                &[&message],
+                Some(self.get_terminated_containers(pod).boxed()),
+                None,
+            )
+            .await?
+        {
+            debug!("{message}");
+        }
+
+        Ok(())
+    }
+
     /// Handles an executor error.
     async fn handle_executor_error(
         &self,
@@ -870,7 +951,7 @@ impl TaskOrchestrator {
         Ok(())
     }
 
-    /// Handles a system error.
+    /// Handles an unspecified system error.
     async fn handle_system_error(&self, tes_id: &str, pod: &Pod) -> Result<(), Error> {
         let outputs = deserialize_items(output_files_file_path(tes_id))?;
 
@@ -880,14 +961,15 @@ impl TaskOrchestrator {
                 tes_id,
                 State::SystemError,
                 &[&format_log_message!(
-                    "task `{tes_id}` has failed due to a system error"
+                    "task `{tes_id}` has failed due to an unspecified system error; contact the \
+                     administrator to diagnose the issue"
                 )],
                 Some(self.get_terminated_containers(pod).boxed()),
                 outputs.as_deref(),
             )
             .await?
         {
-            debug!("task `{tes_id}` has failed due to a system error");
+            debug!("task `{tes_id}` has failed due to an unspecified system error");
         }
 
         Ok(())
@@ -979,31 +1061,22 @@ impl TaskOrchestrator {
         let name = pod.name().context("pod is missing a name")?;
         let ns = pod.namespace().context("pod is missing a namespace")?;
         let status = pod.status.as_ref().context("pod has no status")?;
-
         let pods: Api<Pod> = Api::namespaced(self.client.clone(), &ns);
-
-        let init_statuses = status
-            .init_container_statuses
-            .as_deref()
-            .unwrap_or_default();
-
-        let statuses = status.container_statuses.as_deref().unwrap_or_default();
-
         let now = Timestamp::now();
         let mut containers = Vec::new();
-        for (kind, executor_index, state) in init_statuses
+
+        for status in status
+            .init_container_statuses
+            .as_deref()
+            .unwrap_or_default()
             .iter()
-            .enumerate()
-            .map(|(i, s)| {
-                if i == 0 {
-                    (ContainerKind::Inputs, None, s)
-                } else {
-                    (ContainerKind::Executor, Some(i - 1), s)
-                }
-            })
-            .chain(statuses.iter().map(|s| (ContainerKind::Outputs, None, s)))
-            .filter_map(|(k, i, s)| Some((k, i, s.state.as_ref()?.terminated.as_ref()?)))
+            .chain(status.container_statuses.as_deref().unwrap_or_default())
         {
+            // Only save terminated containers
+            let Some(terminated) = status.state.as_ref().and_then(|s| s.terminated.as_ref()) else {
+                continue;
+            };
+
             // Get the container's output
             let mut output = Retry::spawn_notify(
                 retry_durations(),
@@ -1012,14 +1085,8 @@ impl TaskOrchestrator {
                         .logs(
                             &name,
                             &LogParams {
-                                container: Some(format_container_name(kind, executor_index)),
-                                tail_lines: match kind {
-                                    ContainerKind::Inputs | ContainerKind::Outputs => {
-                                        // For an inputs and outputs pod, read all the log
-                                        None
-                                    }
-                                    ContainerKind::Executor => Some(MAX_EXECUTOR_LOG_LINES),
-                                },
+                                container: Some(status.name.clone()),
+                                tail_lines: Some(MAX_LOG_LINES),
                                 ..Default::default()
                             },
                         )
@@ -1037,18 +1104,15 @@ impl TaskOrchestrator {
             )
             .await?;
 
-            // For executors, extract the real error code which is printed at the end of the
-            // output
-            let exit_code = if kind == ContainerKind::Executor
-                && let Some(pos) = output.rfind(EXIT_PREFIX)
-            {
+            // If the output contains the magic exit prefix, use the contained exit code
+            // rather than the containers
+            let exit_code = if let Some(pos) = output.rfind(EXIT_PREFIX) {
                 let exit = output.split_off(pos);
-                exit[EXIT_PREFIX.len()..]
-                    .trim()
-                    .parse()
-                    .unwrap_or(state.exit_code)
+                exit.get(EXIT_PREFIX.len()..)
+                    .and_then(|code| code.trim().parse().ok())
+                    .unwrap_or(terminated.exit_code)
             } else {
-                state.exit_code
+                terminated.exit_code
             };
 
             // TODO: once k8s supports split logs, read both stdout and stderr streams
@@ -1060,10 +1124,9 @@ impl TaskOrchestrator {
             };
 
             containers.push(TerminatedContainer {
-                kind,
-                executor_index: executor_index.map(|i| i as i32),
+                name: &status.name,
                 start_time: DateTime::from_timestamp_micros(
-                    state
+                    terminated
                         .started_at
                         .as_ref()
                         .map(|t| t.0)
@@ -1072,7 +1135,7 @@ impl TaskOrchestrator {
                 )
                 .context("timestamp out of range")?,
                 end_time: DateTime::from_timestamp_micros(
-                    state
+                    terminated
                         .finished_at
                         .as_ref()
                         .map(|t| t.0)

--- a/orchestrator/src/orchestrator.rs
+++ b/orchestrator/src/orchestrator.rs
@@ -1106,7 +1106,9 @@ impl TaskOrchestrator {
 
             // If the output contains the magic exit prefix, use the contained exit code
             // rather than the containers
-            let exit_code = if let Some(pos) = output.rfind(EXIT_PREFIX) {
+            let exit_code = if status.name.starts_with(EXECUTOR_CONTAINER_PREFIX)
+                && let Some(pos) = output.rfind(EXIT_PREFIX)
+            {
                 let exit = output.split_off(pos);
                 exit.get(EXIT_PREFIX.len()..)
                     .and_then(|code| code.trim().parse().ok())


### PR DESCRIPTION
This PR implements including container output in the system log when an `inputs` or `outputs` container fails.

The intention of these changes is to make it easier for end users to diagnose problems with processing inputs or outputs.

Additionally, the `containers` table in the database has been altered to store the container name to allow storing the output of all containers from the task pods, not just those recognizable by the orchestrator.

Fixes #31.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

Repository specific checklist:

- [x] If you update the supported TES version, you should change the version at
      `planetary::server::TES_VERSION`.
- [x] Make sure that (a) none of the changes conflict with information we lay 
      out in the "Security Notice" section of the `README.md` and (b) anything
      that needs to be added to that section is added.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
