### PR TITLE
fix: relax validate of output path prefixes.

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Fixed handling of `FILE` type outputs with path prefixes ([#46](https://github.com/stjude-rust-labs/planetary/pull/46)).
+
 #### Added
 
 * Added support for local (file://) inputs and outputs ([#41](https://github.com/stjude-rust-labs/planetary/pull/41)).

--- a/api/src/tasks/v1.rs
+++ b/api/src/tasks/v1.rs
@@ -126,12 +126,8 @@ fn validate_task(task: &RequestTask, allow_file_urls: bool) -> Result<()> {
             bail!("output path cannot be `/`");
         }
 
-        // If a path prefix was specified, then the output must be a directory
+        // Validate the path prefix, if present
         if let Some(prefix) = &output.path_prefix {
-            if output.ty != IoType::Directory {
-                bail!("output has a path prefix specified but the output type is not `DIRECTORY`");
-            }
-
             // Ensure the output path pattern is valid
             Pattern::new(&output.path).with_context(|| {
                 format!("invalid output path pattern `{path}`", path = output.path)

--- a/server/src/templating.rs
+++ b/server/src/templating.rs
@@ -260,7 +260,7 @@ impl Template {
             .iter()
             .map(|output| {
                 let mut value = Map::new();
-                value.insert("path".to_string(), output.path.clone().into());
+                value.insert("path".to_string(), output.path_prefix.as_deref().unwrap_or(&output.path).into());
 
                 if let Some(path) = url_to_file_path(&output.url) {
                     // SAFETY: URLs are validated when tasks are created

--- a/server/src/templating.rs
+++ b/server/src/templating.rs
@@ -260,7 +260,10 @@ impl Template {
             .iter()
             .map(|output| {
                 let mut value = Map::new();
-                value.insert("path".to_string(), output.path_prefix.as_deref().unwrap_or(&output.path).into());
+                value.insert(
+                    "path".to_string(),
+                    output.path_prefix.as_deref().unwrap_or(&output.path).into(),
+                );
 
                 if let Some(path) = url_to_file_path(&output.url) {
                     // SAFETY: URLs are validated when tasks are created

--- a/tests/tests/functional.rs
+++ b/tests/tests/functional.rs
@@ -453,7 +453,9 @@ fn file_wildcard_outputs() {
                     "-c",
                     "echo first > /data/out/first.txt && \
                      echo second > /data/out/second.txt && \
-                     echo excluded > /data/out/excluded.log",
+                     echo excluded > /data/out/excluded.log && \
+                     mkdir /data/out/nested && \
+                     echo nested > /data/out/nested/excluded.txt",
                 ],
             }
         ]

--- a/tests/tests/functional.rs
+++ b/tests/tests/functional.rs
@@ -424,6 +424,263 @@ fn local_storage_roundtrip() {
     assert_eq!(env.read_local_file(&username, "outputs/copy.txt"), CONTENT);
 }
 
+/// Tests a task with a wildcard output: a `FILE` output whose `path` is a
+/// glob pattern and whose `path_prefix` is the directory to scan.
+///
+/// Only the files matching the pattern should be recorded as output files in
+/// the task log.
+#[test]
+#[ignore = "requires `docker`, `kind`, `kubectl`, and `helm`"]
+fn file_wildcard_outputs() {
+    let env = TestEnvironment::get();
+    let username = unique_username("file-wildcard-outputs");
+    let client = env.client(Some(&username));
+
+    let id = client.create_task(&json!({
+        "outputs": [
+            {
+                "url": "file:///outputs/wildcard",
+                "path": "/data/out/*.txt",
+                "path_prefix": "/data/out",
+                "type": "FILE",
+            }
+        ],
+        "executors": [
+            {
+                "image": EXECUTOR_IMAGE,
+                "command": [
+                    "sh",
+                    "-c",
+                    "echo first > /data/out/first.txt && \
+                     echo second > /data/out/second.txt && \
+                     echo excluded > /data/out/excluded.log",
+                ],
+            }
+        ]
+    }));
+
+    client.wait_for_task_state(&id, "COMPLETE");
+
+    // The files matching the pattern should be present in local storage
+    assert_eq!(
+        env.read_local_file(&username, "outputs/wildcard/first.txt"),
+        "first\n"
+    );
+    assert_eq!(
+        env.read_local_file(&username, "outputs/wildcard/second.txt"),
+        "second\n"
+    );
+
+    // Only the files matching the pattern should be recorded as output files
+    let (status, body) = client.get_task(&id, "FULL");
+    assert_eq!(status, 200, "unexpected response: {body:#}");
+
+    let mut outputs = body["logs"][0]["outputs"]
+        .as_array()
+        .expect("outputs should be an array")
+        .clone();
+    outputs.sort_by_key(|o| {
+        o["path"]
+            .as_str()
+            .expect("output path should be a string")
+            .to_string()
+    });
+    assert_eq!(
+        outputs,
+        [
+            json!({
+                "url": "file:///outputs/wildcard/first.txt",
+                "path": "/data/out/first.txt",
+                "size_bytes": "6",
+            }),
+            json!({
+                "url": "file:///outputs/wildcard/second.txt",
+                "path": "/data/out/second.txt",
+                "size_bytes": "7",
+            }),
+        ],
+        "unexpected response: {body:#}"
+    );
+}
+
+/// Tests a task with a `DIRECTORY` output.
+///
+/// Every file in the directory, including files in nested directories, should
+/// be recorded as an output file in the task log.
+#[test]
+#[ignore = "requires `docker`, `kind`, `kubectl`, and `helm`"]
+fn directory_outputs() {
+    let env = TestEnvironment::get();
+    let username = unique_username("directory-outputs");
+    let client = env.client(Some(&username));
+
+    let id = client.create_task(&json!({
+        "outputs": [
+            {
+                "url": "file:///outputs/dir",
+                "path": "/data/out",
+                "type": "DIRECTORY",
+            }
+        ],
+        "executors": [
+            {
+                "image": EXECUTOR_IMAGE,
+                "command": [
+                    "sh",
+                    "-c",
+                    "echo first > /data/out/first.txt && \
+                     echo second > /data/out/second.txt && \
+                     mkdir /data/out/nested && \
+                     echo third > /data/out/nested/third.txt",
+                ],
+            }
+        ]
+    }));
+
+    client.wait_for_task_state(&id, "COMPLETE");
+
+    // The directory contents should be present in local storage
+    assert_eq!(
+        env.read_local_file(&username, "outputs/dir/first.txt"),
+        "first\n"
+    );
+    assert_eq!(
+        env.read_local_file(&username, "outputs/dir/second.txt"),
+        "second\n"
+    );
+    assert_eq!(
+        env.read_local_file(&username, "outputs/dir/nested/third.txt"),
+        "third\n"
+    );
+
+    // Every file in the directory should be recorded as an output file
+    let (status, body) = client.get_task(&id, "FULL");
+    assert_eq!(status, 200, "unexpected response: {body:#}");
+
+    let mut outputs = body["logs"][0]["outputs"]
+        .as_array()
+        .expect("outputs should be an array")
+        .clone();
+    outputs.sort_by_key(|o| {
+        o["path"]
+            .as_str()
+            .expect("output path should be a string")
+            .to_string()
+    });
+    assert_eq!(
+        outputs,
+        [
+            json!({
+                "url": "file:///outputs/dir/first.txt",
+                "path": "/data/out/first.txt",
+                "size_bytes": "6",
+            }),
+            json!({
+                "url": "file:///outputs/dir/nested/third.txt",
+                "path": "/data/out/nested/third.txt",
+                "size_bytes": "6",
+            }),
+            json!({
+                "url": "file:///outputs/dir/second.txt",
+                "path": "/data/out/second.txt",
+                "size_bytes": "7",
+            }),
+        ],
+        "unexpected response: {body:#}"
+    );
+}
+
+/// Tests a task with a wildcard `DIRECTORY` output: a `DIRECTORY` output
+/// whose `path` is a glob pattern and whose `path_prefix` is the directory to
+/// scan.
+///
+/// Only the files matching the pattern, including files in nested
+/// directories, should be recorded as output files in the task log.
+#[test]
+#[ignore = "requires `docker`, `kind`, `kubectl`, and `helm`"]
+fn directory_wildcard_outputs() {
+    let env = TestEnvironment::get();
+    let username = unique_username("directory-wildcard-outputs");
+    let client = env.client(Some(&username));
+
+    let id = client.create_task(&json!({
+        "outputs": [
+            {
+                "url": "file:///outputs/dir-wildcard",
+                "path": "/data/out/**/*.txt",
+                "path_prefix": "/data/out",
+                "type": "DIRECTORY",
+            }
+        ],
+        "executors": [
+            {
+                "image": EXECUTOR_IMAGE,
+                "command": [
+                    "sh",
+                    "-c",
+                    "echo first > /data/out/first.txt && \
+                     echo second > /data/out/second.txt && \
+                     mkdir /data/out/nested && \
+                     echo third > /data/out/nested/third.txt && \
+                     echo excluded > /data/out/excluded.log",
+                ],
+            }
+        ]
+    }));
+
+    client.wait_for_task_state(&id, "COMPLETE");
+
+    // The files matching the pattern should be present in local storage
+    assert_eq!(
+        env.read_local_file(&username, "outputs/dir-wildcard/first.txt"),
+        "first\n"
+    );
+    assert_eq!(
+        env.read_local_file(&username, "outputs/dir-wildcard/second.txt"),
+        "second\n"
+    );
+    assert_eq!(
+        env.read_local_file(&username, "outputs/dir-wildcard/nested/third.txt"),
+        "third\n"
+    );
+
+    // Only the files matching the pattern should be recorded as output files
+    let (status, body) = client.get_task(&id, "FULL");
+    assert_eq!(status, 200, "unexpected response: {body:#}");
+
+    let mut outputs = body["logs"][0]["outputs"]
+        .as_array()
+        .expect("outputs should be an array")
+        .clone();
+    outputs.sort_by_key(|o| {
+        o["path"]
+            .as_str()
+            .expect("output path should be a string")
+            .to_string()
+    });
+    assert_eq!(
+        outputs,
+        [
+            json!({
+                "url": "file:///outputs/dir-wildcard/first.txt",
+                "path": "/data/out/first.txt",
+                "size_bytes": "6",
+            }),
+            json!({
+                "url": "file:///outputs/dir-wildcard/nested/third.txt",
+                "path": "/data/out/nested/third.txt",
+                "size_bytes": "6",
+            }),
+            json!({
+                "url": "file:///outputs/dir-wildcard/second.txt",
+                "path": "/data/out/second.txt",
+                "size_bytes": "7",
+            }),
+        ],
+        "unexpected response: {body:#}"
+    );
+}
+
 /// Tests a task with an input specified by embedded content rather than a
 /// URL.
 #[test]

--- a/transporter/CHANGELOG.md
+++ b/transporter/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Fixed handling of `FILE` type outputs with path prefixes ([#46](https://github.com/stjude-rust-labs/planetary/pull/46)).
+
 #### Added
 
 * Added support for local (file://) inputs and outputs ([#41](https://github.com/stjude-rust-labs/planetary/pull/41)).

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -74,6 +74,7 @@ use cloud_copy::cli::handle_events;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures::stream;
+use glob::MatchOptions;
 use glob::Pattern;
 use reqwest::Url;
 use secrecy::SecretString;
@@ -739,7 +740,13 @@ async fn prepare_directory_output(
 
         // If there's a pattern, ensure the container path matches it
         if let Some(pattern) = &pattern
-            && !pattern.matches(container_path)
+            && !pattern.matches_with(
+                container_path,
+                MatchOptions {
+                    require_literal_separator: true,
+                    ..Default::default()
+                },
+            )
         {
             info!("skipping output file `{container_path}` as it does not match the pattern");
             continue;

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -561,7 +561,7 @@ async fn prepare_inputs(
 
             // If the output is a file *without* a path prefix, create it as a file
             // If it has a path prefix, it's really a directory that we're filtering
-            if output.ty == IoType::File && output.path_prefix.is_some() {
+            if output.ty == IoType::File && output.path_prefix.is_none() {
                 // Create the file
                 File::create(&path).await.with_context(|| {
                     format!("failed to create output `{url}`", url = output.url)
@@ -579,7 +579,7 @@ async fn prepare_inputs(
         let path = outputs_dir.join(index.to_string());
         // If the output is a file *without* a path prefix, create it as a file
         // If it has a path prefix, it's really a directory that we're filtering
-        let permissions = if output.ty == IoType::File && output.path_prefix.is_some() {
+        let permissions = if output.ty == IoType::File && output.path_prefix.is_none() {
             // Create the file
             File::create(&path)
                 .await
@@ -696,7 +696,7 @@ async fn prepare_directory_output(
     url: &Url,
     directory: &Path,
 ) -> Result<Vec<OutputFile>> {
-    if output.ty != IoType::Directory || output.path_prefix.is_none() {
+    if output.ty != IoType::Directory && output.path_prefix.is_none() {
         bail!(
             "output `{path}` exists but the output is not a directory",
             path = output.path
@@ -713,7 +713,7 @@ async fn prepare_directory_output(
         };
 
     let mut files = Vec::new();
-    for entry in WalkDir::new(directory) {
+    for entry in WalkDir::new(directory).sort_by_file_name() {
         let entry = entry
             .with_context(|| format!("failed to read directory `{path}`", path = output.path))?;
 

--- a/transporter/src/main.rs
+++ b/transporter/src/main.rs
@@ -559,7 +559,9 @@ async fn prepare_inputs(
                 })?;
             }
 
-            if output.ty == IoType::File {
+            // If the output is a file *without* a path prefix, create it as a file
+            // If it has a path prefix, it's really a directory that we're filtering
+            if output.ty == IoType::File && output.path_prefix.is_some() {
                 // Create the file
                 File::create(&path).await.with_context(|| {
                     format!("failed to create output `{url}`", url = output.url)
@@ -575,7 +577,9 @@ async fn prepare_inputs(
         }
 
         let path = outputs_dir.join(index.to_string());
-        let permissions = if output.ty == IoType::File {
+        // If the output is a file *without* a path prefix, create it as a file
+        // If it has a path prefix, it's really a directory that we're filtering
+        let permissions = if output.ty == IoType::File && output.path_prefix.is_some() {
             // Create the file
             File::create(&path)
                 .await
@@ -692,7 +696,7 @@ async fn prepare_directory_output(
     url: &Url,
     directory: &Path,
 ) -> Result<Vec<OutputFile>> {
-    if output.ty != IoType::Directory {
+    if output.ty != IoType::Directory || output.path_prefix.is_none() {
         bail!(
             "output `{path}` exists but the output is not a directory",
             path = output.path


### PR DESCRIPTION
This PR relaxes the validation of output path prefixes that previously required the output to be a directory.

The `type` on an output is `FILE` but a `path_prefix` is specified, the output is treated like a directory with a wildcard pattern.

Fixes #44.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

Repository specific checklist:

- [x] If you update the supported TES version, you should change the version at
      `planetary::server::TES_VERSION`.
- [x] Make sure that (a) none of the changes conflict with information we lay 
      out in the "Security Notice" section of the `README.md` and (b) anything
      that needs to be added to that section is added.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
